### PR TITLE
Support cross-platform pip installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,31 @@ on:
           - "true"
 
 jobs:
+  portable-install:
+    name: ${{ matrix.os }} / Python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install package using binary dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --only-binary=:all: .
+          python -m pip check
+      - name: Portable command and I/O tests
+        run: |
+          python scripts/smoke_console_scripts.py
+          python -m unittest discover -s tests -p "test_cross_platform_io.py" -v
+          python -m unittest discover -s tests -p "test_gui_launcher.py" -v
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -28,16 +53,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install system tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y bedtools samtools
-
       - name: Install package
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip build twine
-          .venv/bin/python -m pip install -e .
+          .venv/bin/python -m pip install --only-binary=:all: -e .
 
       - name: Build and check release artifacts
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,40 +7,64 @@ permissions:
   contents: read
 
 jobs:
-  pypi:
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-
+  wheels:
+    name: Wheels / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
-
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - uses: docker/setup-qemu-action@v4
+        if: runner.os == 'Linux'
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v3.4.0
+        env:
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_WINDOWS: AMD64
+        with:
+          output-dir: wheelhouse
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ runner.os }}
+          path: wheelhouse/*.whl
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y patchelf
-          python -m pip install --upgrade pip build twine auditwheel
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade build twine
+      - run: python -m build --sdist --outdir dist && python -m twine check dist/*
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sdist
+          path: dist/*.tar.gz
 
-      - name: Build and repair release artifacts
-        run: |
-          python -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip build twine auditwheel
-          ./scripts/build_release.sh
-          .venv/bin/python -m twine check dist/*
-
-      - name: Smoke test repaired wheel
-        run: |
-          python -m venv /tmp/fp-tools-publish-smoke
-          /tmp/fp-tools-publish-smoke/bin/python -m pip install --upgrade pip
-          /tmp/fp-tools-publish-smoke/bin/python -m pip install dist/*.whl
-          .venv/bin/python scripts/smoke_console_scripts.py --bin-dir /tmp/fp-tools-publish-smoke/bin
-
+  pypi:
+    needs: [wheels, sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: "*"
+          merge-multiple: true
+          path: dist
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade twine && python -m twine check dist/*
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: .venv/bin/python -m twine upload dist/*
+        run: python -m twine upload dist/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ git diff --check
 
 ```bash
 .venv/bin/run-yaml-workflow --config examples/gui_configs/call_footprints_single.yml --dry-run
-.venv/bin/fp-tools-gui --host 0.0.0.0 --port 8891 --run-dir examples/gui_runs
+.venv/bin/fp-tools-gui --port 8891 --run-dir examples/gui_runs
 ```
 
 Keep YAML configs portable: paths and sample lists should be explicit, and the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.1.18
+version: 0.2.0rc1
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -4,9 +4,9 @@ Last updated: 2026-08-19
 
 ## Current Baseline
 
-fp-tools is a command-first Python 3.12 package for bulk and pseudobulk
-ATAC-seq footprinting, motif analysis, differential reports, and optional
-browser/YAML wrappers. Scientific workflow logic belongs in
+fp-tools is a command-first Python 3.11–3.13 package for bulk and pseudobulk
+ATAC-seq footprinting, motif analysis, differential reports, and browser/YAML
+wrappers. Scientific workflow logic belongs in
 `src/fp_tools/tools/` and shared helpers in `src/fp_tools/utils/`; CLI and GUI
 layers remain thin.
 
@@ -35,7 +35,7 @@ a separately planned breaking release explicitly changes the contract.
   baseline-matched region classes, six pairwise comparisons, three biological
   replicates, complete motif statistics, and curated all-site aggregate views.
 - Pseudobulk fragment/BAM generation and single-cell signature reporting.
-- Optional Streamlit GUI whose saved YAML runs through `run-yaml-workflow`.
+- Streamlit GUI whose saved YAML runs through `run-yaml-workflow`.
 - Local tests, package builds, GitHub CI, GitHub Pages deployment, and manual
   PyPI publication.
 - Branded GitHub and MkDocs presentation with responsive embedded report and
@@ -80,6 +80,9 @@ a separately planned breaking release explicitly changes the contract.
 8. Keep region-set examples outcome-independent: define groups from external
    annotations, match baseline signal before testing, report all motifs, and
    use explicit display motifs only to configure the initial browser view.
+9. Maintain binary-wheel installation and scientific I/O parity on Windows,
+   macOS, and Linux for Python 3.11–3.13. Raw FASTQ preparation and external
+   MEME programs remain explicit system-tool integrations.
 
 ## Deferred or Experimental Work
 
@@ -101,6 +104,7 @@ help checks, YAML dry runs, `pip check`, strict MkDocs, release artifact checks,
 and relevant focused regressions. Release, GitHub Actions, Pages, and PyPI
 instructions belong only in `RELEASE_CHECKLIST.md`.
 
-The GUI remains an optional wrapper. Future GUI changes must keep direct CLI
-use primary, retain reusable YAML, avoid hosted-service assumptions, and use
-the current static demo and layout as the visual baseline.
+The GUI remains a thin wrapper included in the standard installation. Future
+GUI changes must keep direct CLI use primary, retain reusable YAML, avoid
+hosted-service assumptions, and use the current static demo and layout as the
+visual baseline.

--- a/README.md
+++ b/README.md
@@ -20,20 +20,18 @@
 
 `fp-tools` is a command-first toolkit for ATAC-seq bias correction, footprint
 scoring, motif analysis, replicate-aware comparisons, and single-cell
-footprint signatures. The optional GUI and YAML runner call the same commands.
+footprint signatures. The GUI and YAML runner call the same commands.
 
 ## Install
 
 ```bash
-pip install fp-tools-bio
-```
-
-For the GUI:
-
-```bash
-pip install "fp-tools-bio[gui]"
+python -m pip install fp-tools-bio
 fp-tools-gui
 ```
+
+Python 3.11–3.13 is supported on Windows, macOS, and Linux. Core analysis and
+the GUI install from wheels; raw FASTQ preprocessing uses standard external
+bioinformatics tools (WSL on Windows).
 
 ## Bulk ATAC-seq
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -4,7 +4,8 @@ Use this checklist before publishing `fp-tools-bio` or preparing paper benchmark
 
 ## 1. Environment
 
-- Use Python 3.12 in the project virtualenv.
+- Use a clean Python 3.12 environment for release orchestration. Wheels target
+  Python 3.11–3.13 on Windows, macOS, and Linux.
 - Confirm editable install:
 
 ```bash
@@ -56,20 +57,19 @@ Primary current API checks:
 
 ## 4. Build Artifacts
 
-Build source and wheel artifacts. On Linux releases, install `auditwheel` and
-`patchelf` first so `scripts/build_release.sh` can repair platform wheels to
-manylinux tags accepted by PyPI:
+Release wheels are built by `cibuildwheel` in the manual `Publish` workflow.
+The required artifact set is:
+
+- CPython 3.11, 3.12, and 3.13
+- Windows AMD64
+- macOS x86_64 and arm64
+- manylinux x86_64 and aarch64
+
+Build an sdist locally only for preflight inspection:
 
 ```bash
-.venv/bin/python -m pip install build twine auditwheel patchelf
-./scripts/build_release.sh
-```
-
-The build script uses isolated `python -m build`, removes unrepaired
-`linux_x86_64` wheels when a repaired manylinux wheel is produced, and leaves
-the upload-ready files in `dist/`. Validate metadata before upload:
-
-```bash
+.venv/bin/python -m pip install build twine
+.venv/bin/python -m build --sdist
 .venv/bin/python -m twine check dist/*
 ```
 
@@ -78,7 +78,7 @@ After uploading, verify a fresh install from PyPI:
 ```bash
 python -m venv /tmp/fp-tools-pypi-smoke
 /tmp/fp-tools-pypi-smoke/bin/python -m pip install --upgrade pip
-/tmp/fp-tools-pypi-smoke/bin/python -m pip install "fp-tools-bio[gui]==<version>"
+/tmp/fp-tools-pypi-smoke/bin/python -m pip install --only-binary=:all: "fp-tools-bio==<version>"
 /tmp/fp-tools-pypi-smoke/bin/atac-correct --help >/dev/null
 /tmp/fp-tools-pypi-smoke/bin/plot-aggregate --help >/dev/null
 /tmp/fp-tools-pypi-smoke/bin/fp-tools-gui --help >/dev/null
@@ -88,9 +88,9 @@ The manual GitHub Actions `Publish` workflow uses the repository
 `PYPI_API_TOKEN` secret. Do not paste PyPI tokens into chat, shell history, or
 committed files. Rotate any token that was exposed outside a secret manager.
 
-The preferred publish path is the manual GitHub Actions `Publish` workflow. It
-repairs the Linux wheel, checks metadata, smoke-tests every declared console
-script, and uploads with the configured token.
+The manual GitHub Actions `Publish` workflow builds and tests every wheel,
+checks all artifacts, then uploads the complete set with the configured token.
+Do not publish when any platform wheel is absent.
 
 ## 5. Metadata And Docs
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,7 +19,7 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 | [`plot-aggregate`](#plot-aggregate) | Plot average signal around motif sites or other genomic regions as a static figure or interactive HTML report. |
 | [`review-multi-comparisons`](#review-multi-comparisons) | Combine differential-footprint reports as a scalable browser bundle or one self-contained HTML report. |
 | [`run-yaml-workflow`](#run-yaml-workflow) | Run one or more fp-tools jobs from a reusable YAML configuration. |
-| [`fp-tools-gui`](#fp-tools-gui) | Launch the optional browser interface for configuring and running fp-tools commands. |
+| [`fp-tools-gui`](#fp-tools-gui) | Launch the browser interface for configuring and running fp-tools commands. |
 | [`discover-motifs`](#discover-motifs) | Prepare or run de novo motif discovery from candidate footprint intervals or an existing FASTA file. |
 | [`summarize-motifs`](#summarize-motifs) | Summarize MEME, STREME, DREME, and Tomtom results in a compact report. |
 | [`pseudobulk-fragments`](#pseudobulk-fragments) | Group single-cell ATAC fragments by a cell-annotation column to create pseudobulk inputs. |
@@ -327,10 +327,11 @@ same `{prefix}_*.bw`, `{prefix}_atacorrect.pdf`, and
 **Complete options**
 
 ```text
-usage: atac-correct [-h] [--bams [<bam> ...]] [-g <fasta>] [-p [<bed> ...]]
-                    [--regions-in <bed>] [--regions-out <bed>] [--blacklist <bed>]
-                    [--extend <int>] [--split-strands] [--norm-off]
-                    [--write-tracks [<track> ...]] [--track-off [<track> ...]] [--skip-qc]
+usage: atac-correct [-h] [--bams [<bam> ...]] [--fragments [<fragments.tsv.gz> ...]]
+                    [-g <fasta>] [-p [<bed> ...]] [--regions-in <bed>]
+                    [--regions-out <bed>] [--blacklist <bed>] [--extend <int>]
+                    [--split-strands] [--norm-off] [--write-tracks [<track> ...]]
+                    [--track-off [<track> ...]] [--skip-qc]
                     [--scale-corrected {auto,none,q95}] [--scale-background <bed>]
                     [--scale-corrected-bigwigs [<bigwig> ...]]
                     [--scale-target {median,mean}] [--scale-chrom-sizes <chrom.sizes>]
@@ -363,6 +364,9 @@ Output files:
 
 Required arguments:
   --bams [<bam> ...]               One or more .bam files containing reads to be corrected
+  --fragments [<fragments.tsv.gz> ...]
+                                   One or more 10x-style fragment files; uses cut sites
+                                   directly without creating pseudo-BAMs
   -g <fasta>, --genome <fasta>     A .fasta-file containing whole genomic sequence
   -p [<bed> ...], --peaks [<bed> ...]
                                    One shared merged peak BED, or multiple per-sample peak
@@ -1559,23 +1563,24 @@ options:
 
 <div class="fp-api-card" markdown="1">
 
-Launch the optional browser interface for configuring and running fp-tools
-commands.
+Launch the browser interface for configuring and running fp-tools commands.
 
 **Example command**
 
 ```bash
 fp-tools-gui \
-  --host 0.0.0.0 \
+  --host 127.0.0.1 \
   --port 8891 \
-  --run-dir project/gui_runs
+  --run-dir project/gui_runs \
+  --no-browser
 ```
 
 **Primary inputs**
 
-- `--host` — interface on which the GUI listens.
+- `--host` — interface on which the GUI listens (default: `127.0.0.1`).
 - `--port` — fixed browser port.
 - `--run-dir` — directory for GUI-managed configurations and runs.
+- `--no-browser` — start the server without opening a local browser.
 
 **Main outputs**
 
@@ -1587,18 +1592,43 @@ fp-tools-gui \
 Files under `{run_dir}` are local run state. A saved YAML remains runnable with
 `run-yaml-workflow --config {run_dir}/{timestamp}_{label}/config.yml`.
 
+## Local computer
+
+Run `fp-tools-gui`. A browser opens after the server is ready. If it does not,
+open the local URL printed in the terminal.
+
+## Remote Linux server
+
+Start fp-tools on the server without exposing a network port:
+
+```bash
+fp-tools-gui --no-browser --port 8891
+```
+
+On your computer, create an SSH tunnel and keep that terminal open:
+
+```bash
+ssh -N -L 8891:127.0.0.1:8891 USER@SERVER
+```
+
+Open `http://127.0.0.1:8891`. Binding with `--host 0.0.0.0` is also supported,
+but fp-tools does not add authentication; protect direct network access with a
+firewall, VPN, or reverse proxy.
+
 **Complete options**
 
 ```text
 usage: fp-tools-gui [-h] [--host HOST] [--port PORT] [--run-dir RUN_DIR]
+                    [--no-browser]
 
-Launch the fp-tools Streamlit GUI.
+Launch the fp-tools browser interface.
 
 options:
   -h, --help         show this help message and exit
-  --host HOST        Bind address for the GUI server.
-  --port PORT        Optional fixed port.
+  --host HOST        Bind address (default: 127.0.0.1).
+  --port PORT        Optional fixed port (default: first free port from 8891).
   --run-dir RUN_DIR  Directory for GUI-managed runs.
+  --no-browser       Do not open a local browser automatically.
 ```
 
 </div>
@@ -2097,8 +2127,8 @@ options:
   --outdir OUTDIR       Output directory for the full pseudobulk footprint
                         workflow.
   --genome-sizes GENOME_SIZES
-                        Two-column chromosome sizes file; required for
-                        fragment input cut-site bigWigs and pseudo-BAMs.
+                        Two-column chromosome sizes file used for fragment-
+                        derived cut-site bigWigs.
   --genome GENOME       Genome FASTA for atac-correct.
   --peaks PEAKS         Peak BED used for atac-correct and footprint scoring.
   --blacklist BLACKLIST
@@ -2122,8 +2152,8 @@ options:
   --no-cpm-normalize    Write raw cut counts instead of CPM-normalized cut-
                         site bigWigs for fragment input.
   --top-n TOP_N         Optional top N candidate footprints per group.
-  --read-shift FWD REV  Override the atac-correct read shift for fragment-
-                        derived pseudo-BAMs (default: 0 0).
+  --read-shift FWD REV  Override the atac-correct read shift for fragment cut
+                        sites (default: 0 0).
   --motifs [MOTIFS ...]
                         Optional motif file(s); when provided, run motif-aware
                         diff-footprints on pseudobulk footprint tracks.

--- a/docs/get-started/commands/fp-tools-gui.md
+++ b/docs/get-started/commands/fp-tools-gui.md
@@ -1,22 +1,23 @@
 # [`fp-tools-gui`](../../api.md#fp-tools-gui)
 
-Launch the optional browser interface for configuring and running fp-tools
-commands.
+Launch the browser interface for configuring and running fp-tools commands.
 
 ## Example command
 
 ```bash
 fp-tools-gui \
-  --host 0.0.0.0 \
+  --host 127.0.0.1 \
   --port 8891 \
-  --run-dir project/gui_runs
+  --run-dir project/gui_runs \
+  --no-browser
 ```
 
 ## Primary inputs
 
-- `--host` — interface on which the GUI listens.
+- `--host` — interface on which the GUI listens (default: `127.0.0.1`).
 - `--port` — fixed browser port.
 - `--run-dir` — directory for GUI-managed configurations and runs.
+- `--no-browser` — start the server without opening a local browser.
 
 ## Main outputs
 
@@ -30,3 +31,26 @@ Files under `{run_dir}` are local run state. A saved YAML remains runnable with
 
 Open the [GUI Demo](../../gui.md), or see the
 [complete `fp-tools-gui` reference](../../api.md#fp-tools-gui).
+
+## Local computer
+
+Run `fp-tools-gui`. A browser opens after the server is ready. If it does not,
+open the local URL printed in the terminal.
+
+## Remote Linux server
+
+Start fp-tools on the server without exposing a network port:
+
+```bash
+fp-tools-gui --no-browser --port 8891
+```
+
+On your computer, create an SSH tunnel and keep that terminal open:
+
+```bash
+ssh -N -L 8891:127.0.0.1:8891 USER@SERVER
+```
+
+Open `http://127.0.0.1:8891`. Binding with `--host 0.0.0.0` is also supported,
+but fp-tools does not add authentication; protect direct network access with a
+firewall, VPN, or reverse proxy.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -1,12 +1,20 @@
 # Installation
 
-fp-tools requires Python 3.12 or later.
+fp-tools supports Python 3.11–3.13 on current Windows, macOS, and Linux systems.
 
 ## Command-line package
 
-```bash
-pip install fp-tools-bio
-```
+=== "Windows PowerShell"
+
+    ```powershell
+    py -m pip install --upgrade fp-tools-bio
+    ```
+
+=== "macOS / Linux"
+
+    ```bash
+    python3 -m pip install --upgrade fp-tools-bio
+    ```
 
 Confirm that the commands are available:
 
@@ -30,12 +38,15 @@ Samtools, Bedtools, and HOMER. The doctor report identifies every missing
 program. Commands that start from existing bigWigs do not require the complete
 raw-read toolchain.
 
-## Optional GUI
+## GUI
 
 ```bash
-pip install "fp-tools-bio[gui]"
 fp-tools-gui
 ```
+
+The standard installation includes the GUI. It opens a local browser and
+prints the URL. See [`fp-tools-gui`](commands/fp-tools-gui.md) for remote-server
+access.
 
 The GUI saves YAML configurations that can be run directly with
 [`run-yaml-workflow`](commands/run-yaml-workflow.md).
@@ -49,6 +60,18 @@ python -m pip install -e .
 ```
 
 See the [API Reference](../api.md) for complete command options.
+
+## Platform support
+
+| Platform | Core analysis and GUI | Raw FASTQ preparation | External MEME tools |
+| --- | --- | --- | --- |
+| Windows 10/11 | Native | WSL | WSL |
+| macOS Intel/Apple Silicon | Native | Install command-line tools | Install MEME Suite |
+| Linux x86_64/ARM64 | Native | Install command-line tools | Install MEME Suite |
+
+`prepare-atac` orchestrates tools such as Bowtie 2, SAMtools, BEDTools, fastp,
+and MACS3. De novo discovery can call STREME and Tomtom. These external programs
+are not required for BAM-, fragment-, bigWig-, or BED-based fp-tools analyses.
 
 Next, choose the [bulk ATAC-seq workflow](workflows/bulk-atac-seq.md), the
 [single-cell workflow](workflows/single-cell.md), or an individual command in

--- a/docs/get-started/tool-overview.md
+++ b/docs/get-started/tool-overview.md
@@ -26,7 +26,7 @@ comparison table, ENCODE downloads, and the expected output layout.
 - [`bulk-footprinting`](commands/bulk-footprinting.md) — run the complete bulk workflow from aligned BAM and peak files.
 - [`sc-footprinting`](commands/sc-footprinting.md) — run pseudobulk and per-cell single-cell ATAC-seq footprinting.
 - [`run-yaml-workflow`](commands/run-yaml-workflow.md) — run command-compatible jobs from YAML.
-- [`fp-tools-gui`](commands/fp-tools-gui.md) — launch the optional browser interface.
+- [`fp-tools-gui`](commands/fp-tools-gui.md) — launch the browser interface.
 
 ## De Novo Motif Discovery
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -6,11 +6,10 @@ hide:
 
 # GUI Demo
 
-The optional GUI runs the same fp-tools commands and saves reusable YAML
+The GUI runs the same fp-tools commands and saves reusable YAML
 configurations.
 
 ```bash
-pip install "fp-tools-bio[gui]"
 fp-tools-gui
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,14 @@ hide:
 
 # ATAC-seq footprinting and regulatory motif analysis
 
-`fp-tools` provides command-line and optional browser workflows for bulk and
+`fp-tools` provides command-line and browser workflows for bulk and
 single-cell ATAC-seq footprinting. It connects bias correction, footprint
 scoring, motif analysis, replicate comparisons, and reusable reports.
 
 <div class="fp-badges">
   <a href="https://pypi.org/project/fp-tools-bio/">PyPI</a>
   <a href="https://github.com/oncologylab/fp-tools">GitHub</a>
-  <span>Python 3.12+</span>
+  <span>Python 3.11–3.13</span>
   <span>MIT license</span>
 </div>
 

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.1.18
+#      python -m pip install fp-tools-bio==0.2.0rc1
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.1.18}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc1}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,19 +10,24 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.1.18"
+version = "0.2.0rc1"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
 authors = [{ name = "Yaoxiang Li" }]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 keywords = ["ATAC-seq", "footprinting", "motif", "chromatin", "bioinformatics"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
+  "Operating System :: Microsoft :: Windows :: Windows 10",
+  "Operating System :: Microsoft :: Windows :: Windows 11",
+  "Operating System :: MacOS",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Cython",
   "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
@@ -31,31 +36,29 @@ classifiers = [
 dependencies = [
   "numpy>=1.22,<3.0",
   "scipy>=1.16,<2.0",
-  "pysam>=0.23.3,<0.24.0",
-  "pyBigWig>=0.3.24,<0.4.0",
+  "pysam>=0.23.3,<0.24.0; platform_system != 'Windows'",
+  "bamnostic>=1.3,<2.0; platform_system == 'Windows'",
+  "pyBigWig>=0.3.24,<0.4.0; platform_system == 'Linux' and platform_machine == 'x86_64'",
+  "pybigtools>=0.3.0,<0.4.0",
+  "pyfastx>=2.3.1,<3.0",
   "matplotlib>=3.10,<4.0",
   "pandas>=2.3.3,<3.0",
   "seaborn>=0.13.2,<0.14.0",
-  "pybedtools>=0.12,<0.13",
   "scikit-learn>=1.5,<2.0",
   "tqdm>=4.66,<5.0",
   "kneed>=0.8.5,<0.9.0",
   "adjustText>=1.3.0,<2.0.0",
-  "moods-python>=1.9.4.1,<2.0.0.0",
   "biopython>=1.85,<2.0",
   "logomaker>=0.8.7,<0.9.0",
   "xlsxwriter>=3.2.9,<4.0.0",
   "anndata>=0.12,<0.13",
-  "PyYAML>=6.0,<7.0"
+  "PyYAML>=6.0,<7.0",
+  "streamlit>=1.44,<2.0"
 ]
 
-# Optional feature groups keep the core CLI/scientific install light for cluster and
-# container environments, which typically do not need the Streamlit GUI layer.
 [project.optional-dependencies]
-# Streamlit GUI wrapper: pip install "fp-tools-bio[gui]"
-gui = ["streamlit>=1.44,<2.0"]
-# Convenience meta-extra that pulls in every optional feature.
-all = ["streamlit>=1.44,<2.0"]
+gui = []
+all = []
 docs = [
   "mkdocs>=1.6,<2.0",
   "mkdocs-material>=9.5,<10.0",
@@ -123,10 +126,24 @@ testpaths = ["tests"]
 norecursedirs = ["data", "site", ".git", ".venv"]
 pythonpath = ["."]
 
+[tool.cibuildwheel]
+build = "cp311-* cp312-* cp313-*"
+skip = "*-musllinux_*"
+test-command = [
+  "python -m pip check",
+  "atac-correct --help",
+  "call-footprints --help",
+  "diff-footprints --help",
+  "fp-tools-gui --help"
+]
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.1.18"
+version = "0.2.0rc1"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"
@@ -134,34 +151,35 @@ packages = [{ include = "fp_tools", from = "src" }]
 include = ["src/fp_tools/resources/motifs/*.txt", "src/fp_tools/resources/static_browser/*"]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<4.0"
+python = ">=3.11,<4.0"
 numpy = ">=1.22,<3.0"
 scipy = ">=1.16,<2.0"
-pysam = ">=0.23.3,<0.24.0"
-pybigwig = ">=0.3.24,<0.4.0"
+pysam = { version = ">=0.23.3,<0.24.0", markers = "platform_system != 'Windows'" }
+bamnostic = { version = ">=1.3,<2.0", markers = "platform_system == 'Windows'" }
+pybigwig = { version = ">=0.3.24,<0.4.0", markers = "platform_system == 'Linux' and platform_machine == 'x86_64'" }
+pybigtools = ">=0.3.0,<0.4.0"
+pyfastx = ">=2.3.1,<3.0"
 matplotlib = ">=3.10,<4.0"
 pandas = ">=2.3.3,<3.0"
 seaborn = ">=0.13.2,<0.14.0"
-pybedtools = ">=0.12,<0.13"
 scikit-learn = ">=1.5,<2.0"
 tqdm = ">=4.66,<5.0"
 kneed = ">=0.8.5,<0.9.0"
 adjusttext = ">=1.3.0,<2.0.0"
-moods-python = ">=1.9.4.1,<2.0.0.0"
 biopython = ">=1.85,<2.0"
 logomaker = ">=0.8.7,<0.9.0"
 xlsxwriter = ">=3.2.9,<4.0.0"
 anndata = ">=0.12,<0.13"
 pyyaml = ">=6.0,<7.0"
-streamlit = { version = ">=1.44,<2.0", optional = true }
+streamlit = ">=1.44,<2.0"
 mkdocs = { version = ">=1.6,<2.0", optional = true }
 mkdocs-material = { version = ">=9.5,<10.0", optional = true }
 mkdocstrings = { version = ">=0.26,<1.0", extras = ["python"], optional = true }
 mkdocs-git-revision-date-localized-plugin = { version = ">=1.2,<2.0", optional = true }
 
 [tool.poetry.extras]
-gui = ["streamlit"]
-all = ["streamlit"]
+gui = []
+all = []
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings", "mkdocs-git-revision-date-localized-plugin"]
 
 [tool.poetry.scripts]

--- a/scripts/smoke_console_scripts.py
+++ b/scripts/smoke_console_scripts.py
@@ -7,7 +7,9 @@ import argparse
 import os
 from pathlib import Path
 import subprocess
+import shutil
 import sys
+import sysconfig
 import tomllib
 
 
@@ -28,7 +30,7 @@ def main() -> int:
     parser.add_argument(
         "--bin-dir",
         type=Path,
-        default=Path(sys.executable).parent,
+        default=Path(sysconfig.get_path("scripts")),
         help="Directory containing installed console scripts.",
     )
     args = parser.parse_args()
@@ -36,9 +38,12 @@ def main() -> int:
     failures = []
     env = os.environ.copy()
     for command in console_scripts():
-        executable = args.bin_dir / command
+        executable = shutil.which(command, path=str(args.bin_dir))
+        if executable is None:
+            failures.append((command, 127, f"not found in {args.bin_dir}"))
+            continue
         result = subprocess.run(
-            [str(executable), "--help"],
+            [executable, "--help"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             text=True,

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.18"
+__version__ = "0.2.0rc1"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/cli_gui.py
+++ b/src/fp_tools/cli_gui.py
@@ -1,4 +1,4 @@
-"""Launcher for the isolated fp-tools Streamlit GUI."""
+"""Launcher for the command-backed fp-tools Streamlit GUI."""
 
 from __future__ import annotations
 
@@ -9,37 +9,35 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
+import threading
+import time
+import webbrowser
 from pathlib import Path
-from urllib.error import URLError
-from urllib.request import Request, urlopen
 
 from fp_tools.gui_jobs import default_gui_run_dir
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Launch the fp-tools Streamlit GUI.")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address for the GUI server.")
-    parser.add_argument("--port", type=int, default=None, help="Optional fixed port.")
+    parser = argparse.ArgumentParser(description="Launch the fp-tools browser interface.")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1).")
+    parser.add_argument("--port", type=int, default=None, help="Optional fixed port (default: first free port from 8891).")
     parser.add_argument("--run-dir", default=str(default_gui_run_dir()), help="Directory for GUI-managed runs.")
+    parser.add_argument("--no-browser", action="store_true", help="Do not open a local browser automatically.")
     args = parser.parse_args()
 
     if importlib.util.find_spec("streamlit") is None:
-        raise SystemExit(
-            "Streamlit is not installed in the current environment. "
-            'Install the optional GUI extra to use fp-tools-gui: pip install "fp-tools-bio[gui]".'
-        )
+        raise SystemExit("Streamlit is missing. Reinstall with: python -m pip install --upgrade fp-tools-bio")
 
     port = args.port if args.port is not None else _find_free_port()
     access_urls = _access_urls(args.host, port)
     _write_state(args.host, port, args.run_dir, access_urls)
+    for message in _startup_messages(args.host, port, Path(args.run_dir).expanduser()):
+        print(message, flush=True)
 
-    print(f"fp-tools GUI bind address: {args.host}:{port}")
-    print("Access URLs:")
-    for url in access_urls:
-        print(f"  {url}")
-    if args.host in {"0.0.0.0", "::"}:
-        print(f"External access requires TCP port {port} to be open in the host firewall or cloud security group.")
-    print(f"Run directory: {Path(args.run_dir).expanduser()}")
+    local_url = f"http://127.0.0.1:{port}"
+    if not args.no_browser and args.host in {"127.0.0.1", "localhost", "::1"}:
+        threading.Thread(target=_open_browser_when_ready, args=(port, local_url), daemon=True).start()
 
     app_path = Path(__file__).with_name("gui_app.py")
     env = os.environ.copy()
@@ -59,7 +57,49 @@ def main() -> None:
         "--browser.gatherUsageStats",
         "false",
     ]
-    raise SystemExit(subprocess.run(command, env=env).returncode)
+    try:
+        return_code = subprocess.run(command, env=env).returncode
+    except KeyboardInterrupt:
+        return_code = 130
+    raise SystemExit(return_code)
+
+
+def _startup_messages(host: str, port: int, run_dir: Path) -> list[str]:
+    messages = [
+        "fp-tools GUI",
+        f"Open locally: http://127.0.0.1:{port}",
+        f"Run directory: {run_dir}",
+        "Stop the server with Ctrl+C.",
+    ]
+    if host in {"127.0.0.1", "localhost", "::1"}:
+        messages.extend(
+            [
+                "Remote Linux server: keep this process running, then run the following on your computer:",
+                f"  ssh -N -L {port}:127.0.0.1:{port} USER@SERVER",
+                f"Then open http://127.0.0.1:{port} on your computer.",
+            ]
+        )
+    elif host in {"0.0.0.0", "::"}:
+        messages.extend(
+            [
+                "Network mode is enabled. Open http://SERVER_IP:%d from an allowed network." % port,
+                "Warning: fp-tools does not add authentication; use a firewall, VPN, or SSH tunnel.",
+            ]
+        )
+    else:
+        messages.append(f"Open from a reachable client: http://{host}:{port}")
+    return messages
+
+
+def _open_browser_when_ready(port: int, url: str, timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                webbrowser.open(url)
+                return
+        except OSError:
+            time.sleep(0.15)
 
 
 def _find_free_port(start: int = 8891, end: int = 8999) -> int:
@@ -73,26 +113,17 @@ def _find_free_port(start: int = 8891, end: int = 8999) -> int:
 
 def _write_state(host: str, port: int, run_dir: str, access_urls: list[str]) -> None:
     cache_dir = _state_dir(Path(run_dir).expanduser())
-    state_path = cache_dir / "gui.json"
-    state_path.write_text(
-        json.dumps(
-            {
-                "host": host,
-                "port": port,
-                "run_dir": str(Path(run_dir).expanduser()),
-                "access_urls": access_urls,
-            },
-            indent=2,
-        ),
+    (cache_dir / "gui.json").write_text(
+        json.dumps({"host": host, "port": port, "run_dir": str(Path(run_dir).expanduser()), "access_urls": access_urls}, indent=2),
         encoding="utf-8",
     )
 
 
 def _state_dir(run_dir: Path) -> Path:
     candidates = [
-        Path.home() / ".cache" / "fp-tools",
+        Path(os.environ.get("LOCALAPPDATA", "")) / "fp-tools" if os.name == "nt" else Path.home() / ".cache" / "fp-tools",
         run_dir / ".gui-state",
-        Path("/tmp") / "fp-tools-gui-state",
+        Path(tempfile.gettempdir()) / "fp-tools-gui-state",
     ]
     for path in candidates:
         try:
@@ -104,79 +135,10 @@ def _state_dir(run_dir: Path) -> Path:
 
 
 def _access_urls(host: str, port: int) -> list[str]:
-    hosts = [host]
     if host in {"0.0.0.0", "::"}:
-        hosts = ["127.0.0.1", *_candidate_public_hosts()]
-    urls: list[str] = []
-    for candidate in hosts:
-        if not candidate or candidate in {"0.0.0.0", "::"}:
-            continue
-        url = f"http://{candidate}:{port}"
-        if url not in urls:
-            urls.append(url)
-    return urls or [f"http://127.0.0.1:{port}"]
+        return [f"http://127.0.0.1:{port}", f"http://SERVER_IP:{port}"]
+    return [f"http://{host}:{port}"]
 
 
-def _candidate_public_hosts() -> list[str]:
-    candidates: list[str] = []
-    for candidate in _hostname_ips() + [_outbound_ip()] + _metadata_public_ips():
-        if not candidate:
-            continue
-        if candidate.startswith("127.") or candidate == "0.0.0.0":
-            continue
-        if candidate not in candidates:
-            candidates.append(candidate)
-    return candidates
-
-
-def _hostname_ips() -> list[str]:
-    names = {socket.gethostname()}
-    try:
-        names.add(socket.getfqdn())
-    except OSError:
-        pass
-    ips: list[str] = []
-    for name in names:
-        try:
-            for family, _, _, _, sockaddr in socket.getaddrinfo(name, None, socket.AF_INET):
-                if family == socket.AF_INET and sockaddr[0] not in ips:
-                    ips.append(sockaddr[0])
-        except OSError:
-            continue
-    return ips
-
-
-def _outbound_ip() -> str:
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-            sock.connect(("8.8.8.8", 80))
-            return str(sock.getsockname()[0])
-    except OSError:
-        return ""
-
-
-def _metadata_public_ips() -> list[str]:
-    urls = [
-        ("http://169.254.169.254/latest/meta-data/public-ipv4", 2.0),
-        ("http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address", 0.35),
-        ("http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2021-02-01&format=text", 0.35),
-    ]
-    ips: list[str] = []
-    for url, timeout in urls:
-        request = Request(url, headers={"Metadata": "true"})
-        try:
-            with urlopen(request, timeout=timeout) as response:
-                value = response.read(128).decode("utf-8", errors="ignore").strip()
-        except (OSError, URLError, TimeoutError):
-            continue
-        if _is_ipv4(value) and value not in ips:
-            ips.append(value)
-    return ips
-
-
-def _is_ipv4(value: str) -> bool:
-    try:
-        socket.inet_aton(value)
-    except OSError:
-        return False
-    return value.count(".") == 3
+if __name__ == "__main__":
+    main()

--- a/src/fp_tools/gui_jobs.py
+++ b/src/fp_tools/gui_jobs.py
@@ -48,13 +48,18 @@ def launch_config_async(
     command = [sys.executable, "-m", "fp_tools.cli_batch", "--config", str(config_path), "--run-root", str(run_root)]
 
     with stdout_path.open("w", encoding="utf-8") as stdout_handle, stderr_path.open("w", encoding="utf-8") as stderr_handle:
+        session_options = (
+            {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+            if os.name == "nt"
+            else {"start_new_session": True}
+        )
         process = subprocess.Popen(
             command,
             stdout=stdout_handle,
             stderr=stderr_handle,
             text=True,
-            start_new_session=True,
             cwd=Path.cwd(),
+            **session_options,
         )
 
     status = {

--- a/src/fp_tools/parsers.py
+++ b/src/fp_tools/parsers.py
@@ -36,6 +36,7 @@ def add_atacorrect_arguments(parser):
 	#Required arguments
 	reqargs = parser.add_argument_group('Required arguments')
 	reqargs.add_argument('--bams', metavar="<bam>", nargs="*", help="One or more .bam files containing reads to be corrected")
+	reqargs.add_argument('--fragments', metavar="<fragments.tsv.gz>", nargs="*", help="One or more 10x-style fragment files; uses cut sites directly without creating pseudo-BAMs")
 	reqargs.add_argument('-g', '--genome', metavar="<fasta>", help="A .fasta-file containing whole genomic sequence")
 	reqargs.add_argument('-p', '--peaks', metavar="<bed>", nargs="*", help="One shared merged peak BED, or multiple per-sample peak BEDs to merge internally")
 

--- a/src/fp_tools/tools/atacorrect.py
+++ b/src/fp_tools/tools/atacorrect.py
@@ -35,8 +35,9 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 
 #Bio-specific packages
-import pyBigWig
-import pysam
+from fp_tools.utils import bigwig as pyBigWig
+from fp_tools.utils.alignment import index_alignment, open_alignment
+from fp_tools.utils.fasta import open_fasta
 
 #Internal functions and classes
 from fp_tools.parsers import add_atacorrect_arguments
@@ -256,14 +257,18 @@ def run_atacorrect(args):
 		args.outdir = str(project)
 
 	bams = _compact_list(getattr(args, "bams", None))
-	if not bams:
-		sys.exit("Error: No .bam-file given. Use --bams <reads.bam> [<more_reads.bam> ...]")
+	fragments = _compact_list(getattr(args, "fragments", None))
+	if bams and fragments:
+		sys.exit("Error: use either --bams or --fragments, not both")
+	inputs = fragments or bams
+	if not inputs:
+		sys.exit("Error: provide --bams <reads.bam> or --fragments <fragments.tsv.gz>")
 	if args.genome == None:
 		sys.exit("Error: No .fasta-file given")
 	if not _compact_list(getattr(args, "peaks", None)):
 		sys.exit("Error: No .peaks-file given")
-	if len(bams) > 1 and getattr(args, "prefix", None):
-		sys.exit("Error: --prefix can only be used with a single --bams input. Use --sample-names for multi-BAM runs.")
+	if len(inputs) > 1 and getattr(args, "prefix", None):
+		sys.exit("Error: --prefix can only be used with a single input. Use --sample-names for multi-sample runs.")
 
 	base_outdir = os.path.abspath(args.outdir) if args.outdir != None else os.path.abspath(os.getcwd())
 	sample_output_root = getattr(args, "sample_output_root", None)
@@ -271,10 +276,10 @@ def run_atacorrect(args):
 		sample_output_root = os.path.abspath(sample_output_root)
 		if not getattr(args, "outdir", None):
 			base_outdir = sample_output_root
-	sample_names = _sample_names_from_bams(bams, getattr(args, "sample_names", None))
+	sample_names = _sample_names_from_bams(inputs, getattr(args, "sample_names", None))
 	peak_files = _compact_list(args.peaks)
 	preflight_logger = FpToolsLogger("atac-correct", getattr(args, "verbosity", 3))
-	_warn_peak_sample_mismatches(bams, sample_names, peak_files, preflight_logger)
+	_warn_peak_sample_mismatches(inputs, sample_names, peak_files, preflight_logger)
 	peaks_for_run = _merge_peak_files(args.peaks, base_outdir, getattr(args, "merged_peaks_out", None))
 	if is_project_layout(getattr(args, "layout", None)) and getattr(args, "sample_table", None):
 		project = project_root(getattr(args, "outdir", None))
@@ -282,16 +287,19 @@ def run_atacorrect(args):
 	corrected_bigwigs = []
 
 	sample_args_list = []
-	for bam, sample_name in zip(bams, sample_names):
+	for bam, sample_name in zip(inputs, sample_names):
 		sample_args = deepcopy(args)
 		sample_args.bam = bam
-		sample_args.bams = [bam]
+		sample_args.bams = [] if fragments else [bam]
 		sample_args.peaks = peaks_for_run
-		sample_args.prefix = args.prefix if len(bams) == 1 and args.prefix else sample_name
+		sample_args.input_type = "fragments" if fragments else "bam"
+		if fragments:
+			sample_args.read_shift = [0, 0]
+		sample_args.prefix = args.prefix if len(inputs) == 1 and args.prefix else sample_name
 		if sample_output_root:
 			sample_args.outdir = os.path.join(sample_output_root, sample_name, "atac_correct")
 		else:
-			sample_args.outdir = base_outdir if len(bams) == 1 else os.path.join(base_outdir, sample_name)
+			sample_args.outdir = base_outdir if len(inputs) == 1 else os.path.join(base_outdir, sample_name)
 		sample_args.scale_corrected = "none"
 		sample_args._scale_after_single = False
 		corrected_bigwigs.extend(_corrected_output_paths_for_args(sample_args))
@@ -320,7 +328,7 @@ def run_atacorrect(args):
 				future.result()
 
 	args.outdir = base_outdir
-	if len(bams) == 1:
+	if len(inputs) == 1:
 		args.prefix = args.prefix if args.prefix else sample_names[0]
 	mode = getattr(args, "scale_corrected", "auto")
 	if mode != "none":
@@ -415,10 +423,12 @@ def _run_atacorrect_single(args):
 	#----------------------------------------------------------------------------------------------------#
 
 	logger.info("Reading info from .bam file")
-	bamfile = pysam.AlignmentFile(args.bam, "rb")
+	bamfile = open_alignment(args.bam, "rb")
 	if bamfile.has_index() == False:
-		logger.warning("No index found for bamfile - creating one via pysam.")
-		pysam.index(args.bam)
+		if index_alignment(args.bam):
+			logger.warning("No index found for bamfile; created one for faster access.")
+		else:
+			logger.warning("No BAM index found; using the portable sequential-scan cache.")
 
 	bam_references = bamfile.references 	#chromosomes in correct order
 	bam_chrom_info = dict(zip(bamfile.references, bamfile.lengths))
@@ -426,10 +436,16 @@ def _run_atacorrect_single(args):
 	bamfile.close()
 
 	logger.info("Reading info from .fasta file")
-	fastafile = pysam.FastaFile(args.genome)
+	fastafile = open_fasta(args.genome)
 	fasta_chrom_info = dict(zip(fastafile.references, fastafile.lengths))
 	logger.debug("fasta_chrom_info: {0}".format(fasta_chrom_info))
 	fastafile.close()
+
+	# Compare chrom lengths for BAM input. Fragment files do not carry chromosome
+	# sizes, so the FASTA header is authoritative for their synthetic read view.
+	if getattr(args, "input_type", "bam") == "fragments":
+		bam_references = list(fasta_chrom_info)
+		bam_chrom_info = dict(fasta_chrom_info)
 
 	#Compare chrom lengths
 	chrom_in_common = set(bam_chrom_info.keys()).intersection(fasta_chrom_info.keys())

--- a/src/fp_tools/tools/atacorrect_functions.py
+++ b/src/fp_tools/tools/atacorrect_functions.py
@@ -25,7 +25,8 @@ from scipy.optimize import curve_fit
 import pickle
 
 #Bio-specific packages
-import pysam
+from fp_tools.utils.alignment import open_alignment
+from fp_tools.utils.fasta import open_fasta
 
 #Internal functions and classes
 from fp_tools.utils.sequences import SequenceMatrix, GenomicSequence
@@ -89,7 +90,7 @@ def count_reads(regions_list, params):
 
 	bam_f = params.bam
 	read_shift = params.read_shift
-	bam_obj = pysam.AlignmentFile(bam_f, "rb")
+	bam_obj = open_alignment(bam_f, "rb")
 
 	log_q = params.log_q
 	logger = FpToolsLogger("", params.verbosity, log_q) #sending all logger calls to log_q
@@ -127,8 +128,8 @@ def bias_estimation(regions_list, params):
 	logger = FpToolsLogger("", params.verbosity, params.log_q) 	#sending all logger calls to log_q
 
 	#Open objects for reading
-	bam_obj = pysam.AlignmentFile(bam_f, "rb")
-	fasta_obj = pysam.FastaFile(fasta_f)
+	bam_obj = open_alignment(bam_f, "rb")
+	fasta_obj = open_fasta(fasta_f)
 	chrom_lengths = dict(zip(bam_obj.references, bam_obj.lengths))  #Chromosome boundaries from bam_obj
 
 	bias_obj = AtacBias(L, params.score_mat)
@@ -217,8 +218,8 @@ def bias_correction(regions_list, params, bias_obj):
 	post_bias = {strand: SequenceMatrix.create(L, "PWM") for strand in strands} if collect_qc else None
 
 	#Open bamfile and fasta
-	bam_obj = pysam.AlignmentFile(bam_f, "rb")
-	fasta_obj = pysam.FastaFile(fasta_f)
+	bam_obj = open_alignment(bam_f, "rb")
+	fasta_obj = open_fasta(fasta_f)
 
 	out_signals = {}
 	

--- a/src/fp_tools/tools/candidates.py
+++ b/src/fp_tools/tools/candidates.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 
 
 @dataclass(frozen=True)

--- a/src/fp_tools/tools/diff_footprint_helpers.py
+++ b/src/fp_tools/tools/diff_footprint_helpers.py
@@ -37,8 +37,8 @@ from matplotlib.lines import Line2D
 from adjustText import adjust_text  # noqa: F401
 
 # Bio
-import pyBigWig
-import pysam
+from fp_tools.utils import bigwig as pyBigWig
+from fp_tools.utils.fasta import open_fasta
 
 # Internal (fp_tools namespace)
 from fp_tools.utils.regions import *
@@ -139,7 +139,7 @@ def get_gc_content(regions, fasta):
     """Mean GC fraction inside regions."""
     nuc_count = {"T": 0, "t": 0, "A": 0, "a": 0, "G": 1, "g": 1, "C": 1, "c": 1}
     gc = 0; total = 0
-    fasta_obj = pysam.FastaFile(fasta)
+    fasta_obj = open_fasta(fasta)
     for region in regions:
         seq = fasta_obj.fetch(region.chrom, region.start, region.end)
         gc += sum([nuc_count.get(nuc, 0.5) for nuc in seq])
@@ -171,7 +171,7 @@ def scan_and_score(regions, motifs_obj, args, log_q, qs):
             sample_bigwigs[sample_name] = pyBigWig.open(args.signals[signal_idx], "rb")
             signal_to_sample[signal_idx] = sample_name
 
-    fasta_obj = pysam.FastaFile(args.genome)
+    fasta_obj = open_fasta(args.genome)
     chrom_boundaries = dict(zip(fasta_obj.references, fasta_obj.lengths))
 
     rand_window = 200
@@ -296,15 +296,12 @@ def process_tfbs(TF_name, args, log2fc_params, bed_rows=None):
     diff_dist = scipy.stats.norm
 
     if args.output_peaks is not None and bed_rows is None:
-        # Import lazily so diff-footprints --help and parser-only paths do not touch
-        # pybedtools/genomepy cache initialization.
-        from pybedtools import BedTool
+        from fp_tools.utils.intervals import intersect_bed
 
-        output_bt = BedTool(args.output_peaks)
-        sites_bt = BedTool(filename)
-        intersection = sites_bt.intersect(output_bt, u=True)
-        filename = intersection.fn
-        tmp_files.append(intersection.fn)
+        intersection_path = filename + ".output_peaks.bed"
+        intersect_bed(filename, args.output_peaks, intersection_path)
+        filename = intersection_path
+        tmp_files.append(intersection_path)
 
     stime = datetime.now()
     header = ["TFBS_chr", "TFBS_start", "TFBS_end", "TFBS_name", "TFBS_score", "TFBS_strand"] \

--- a/src/fp_tools/tools/diff_footprints.py
+++ b/src/fp_tools/tools/diff_footprints.py
@@ -23,6 +23,7 @@ import random
 import shutil
 import copy
 import tempfile
+import threading
 import zipfile
 import subprocess
 import numpy as np
@@ -48,8 +49,8 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 
 # Bio
-import pysam
-import pyBigWig as pybw
+from fp_tools.utils.fasta import open_fasta
+from fp_tools.utils import bigwig as pybw
 
 # Internal (fp_tools namespace)
 from fp_tools.parsers import add_diff_footprints_arguments
@@ -398,11 +399,14 @@ def _async_remove_tree(path):
     if not base.startswith(("fp_tools_match_shared_", "fp_tools_diff_tfbs_")):
         shutil.rmtree(path, ignore_errors=True)
         return
-    subprocess.Popen(
-        ["rm", "-rf", path],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
+    threading.Thread(target=shutil.rmtree, args=(path,), kwargs={"ignore_errors": True}, daemon=True).start()
+
+
+def _subprocess_session_options():
+    return (
+        {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+        if os.name == "nt"
+        else {"start_new_session": True}
     )
 
 
@@ -1436,7 +1440,7 @@ def _launch_async_match_motif_bed_materialization(sample_args_list, cores_per_sa
             [sys.executable, "-c", code],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            start_new_session=True,
+            **_subprocess_session_options(),
         )
 
 
@@ -2171,7 +2175,7 @@ def run_diff_footprints(args):
     # boundaries vs fasta / signals
     logger.info("Checking for match between --peaks and --fasta/--signals boundaries")
     logger.info(f"- Comparing peaks to {args.genome}")
-    fasta_obj = pysam.FastaFile(args.genome)
+    fasta_obj = open_fasta(args.genome)
     fasta_boundaries = dict(zip(fasta_obj.references, fasta_obj.lengths))
     fasta_obj.close()
     logger.debug(f"Fasta boundaries: {fasta_boundaries}")

--- a/src/fp_tools/tools/find_signature_fp.py
+++ b/src/fp_tools/tools/find_signature_fp.py
@@ -20,7 +20,10 @@ from matplotlib.colors import ListedColormap, TwoSlopeNorm
 from matplotlib.ticker import MaxNLocator
 import numpy as np
 import pandas as pd
-import pysam
+try:
+    import pysam
+except ImportError:  # Fragment scanning remains available without tabix on Windows.
+    pysam = None
 from sklearn.neighbors import NearestNeighbors
 
 
@@ -287,7 +290,7 @@ def ensure_tabix_index(fragments: Path, create_index: bool) -> bool:
     index_path = Path(str(fragments) + ".tbi")
     if index_path.exists():
         return True
-    if not create_index:
+    if not create_index or pysam is None:
         return False
     pysam.tabix_index(str(fragments), preset="bed", force=True, keep_original=True)
     return index_path.exists()

--- a/src/fp_tools/tools/normalize_bigwig.py
+++ b/src/fp_tools/tools/normalize_bigwig.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 from fp_tools.utils.project_layout import (
     corrected_bigwig_path,
     is_project_layout,

--- a/src/fp_tools/tools/plot_aggregate.py
+++ b/src/fp_tools/tools/plot_aggregate.py
@@ -22,7 +22,7 @@ import matplotlib as mpl
 mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 from sklearn import preprocessing
 
 from fp_tools.parsers import add_aggregate_arguments
@@ -420,9 +420,7 @@ def _resolve_match_dir_tfbs(args, logger):
 def run_aggregate(args):
     """Create aggregate plots and optional aggregate exports."""
 
-    # Import lazily so plot-aggregate --help does not trigger pybedtools/genomepy
-    # cache initialization before argument parsing.
-    import pybedtools as pb
+    from fp_tools.utils.intervals import filter_regions
 
     apply_pdf_style()
     logger = FpToolsLogger("plot-aggregate", args.verbosity)
@@ -566,16 +564,14 @@ def run_aggregate(args):
             tfbs_f = args.TFBS[tfbs_idx]
             region_f = args.regions[region_idx]
 
-            overlap = pb.BedTool(tfbs_f).intersect(pb.BedTool(region_f), u=True)
             name = args.TFBS_labels[tfbs_idx] + " <OVERLAPPING> " + args.region_labels[region_idx]
             region_names.append(name)
-            regions_dict[name] = RegionList().from_bed(overlap.fn)
+            regions_dict[name] = filter_regions(RegionList().from_bed(tfbs_f), region_f)
 
             if args.negate:
-                overlap_neg = pb.BedTool(tfbs_f).intersect(pb.BedTool(region_f), v=True)
                 name = args.TFBS_labels[tfbs_idx] + " <NOT OVERLAPPING> " + args.region_labels[region_idx]
                 region_names.append(name)
-                regions_dict[name] = RegionList().from_bed(overlap_neg.fn)
+                regions_dict[name] = filter_regions(RegionList().from_bed(tfbs_f), region_f, invert=True)
     else:
         region_names = list(args.TFBS_labels)
         regions_dict = {
@@ -588,20 +584,17 @@ def run_aggregate(args):
     if len(args.whitelist) > 0 or len(args.blacklist) > 0:
         logger.info("Subsetting regions on whitelist/blacklist")
         for regions_id in regions_dict:
-            sites = pb.BedTool(regions_dict[regions_id].as_bed(), from_string=True)
             logger.stats(f"Found {len(regions_dict[regions_id])} sites in {regions_id}")
 
             if len(args.whitelist) > 0:
                 for whitelist_f in args.whitelist:
-                    sites = sites.intersect(pb.BedTool(whitelist_f), u=True)
-                    logger.stats(f"Overlapped to whitelist -> {len(sites)}")
+                    regions_dict[regions_id] = filter_regions(regions_dict[regions_id], whitelist_f)
+                    logger.stats(f"Overlapped to whitelist -> {len(regions_dict[regions_id])}")
 
             if len(args.blacklist) > 0:
                 for blacklist_f in args.blacklist:
-                    sites = sites.intersect(pb.BedTool(blacklist_f), v=True)
-                    logger.stats(f"Removed blacklist -> {len(sites)}")
-
-            regions_dict[regions_id] = RegionList().from_bed(sites.fn)
+                    regions_dict[regions_id] = filter_regions(regions_dict[regions_id], blacklist_f, invert=True)
+                    logger.stats(f"Removed blacklist -> {len(regions_dict[regions_id])}")
 
     motif_widths = {}
     for regions_id, site_list in regions_dict.items():

--- a/src/fp_tools/tools/plot_aggregate_batch.py
+++ b/src/fp_tools/tools/plot_aggregate_batch.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 
 
 DEFAULT_COLORS = ["#2563eb", "#dc2626", "#16a34a", "#9333ea", "#f97316", "#0891b2", "#7c3aed", "#64748b"]

--- a/src/fp_tools/tools/prepare_atac.py
+++ b/src/fp_tools/tools/prepare_atac.py
@@ -26,8 +26,11 @@ from pathlib import Path
 from typing import Any, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-import pyBigWig
-import pysam
+from fp_tools.utils import bigwig as pyBigWig
+try:
+    import pysam
+except ImportError:  # Raw-read preparation is documented through WSL on Windows.
+    pysam = None
 import yaml
 
 
@@ -1557,10 +1560,18 @@ def _available_memory_gb() -> float:
                 return int(line.split()[1]) / (1024**2)
     except (OSError, ValueError, IndexError):
         pass
-    return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE") / (1024**3)
+    try:
+        return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE") / (1024**3)
+    except (AttributeError, OSError, ValueError):
+        return 8.0
 
 
 def run_preprocessing(args: argparse.Namespace) -> int:
+    if os.name == "nt":
+        raise SystemExit(
+            "prepare-atac requires Unix bioinformatics executables. On Windows, run it in WSL; "
+            "the downstream fp-tools commands and GUI run natively."
+        )
     overrides: dict[str, Any] = {"profile": args.profile} if args.profile else {}
     resource_overrides = {
         key: value

--- a/src/fp_tools/tools/pseudobulk.py
+++ b/src/fp_tools/tools/pseudobulk.py
@@ -14,11 +14,9 @@ from pathlib import Path
 
 import pandas as pd
 import yaml
+from fp_tools.utils.alignment import open_alignment
 
-try:
-    import pyBigWig
-except ImportError:  # pragma: no cover - dependency is declared, keep import-time failure friendly
-    pyBigWig = None
+from fp_tools.utils import bigwig as pyBigWig
 
 try:
     import pysam
@@ -121,8 +119,6 @@ def write_cutsite_bigwig(
 ) -> Path:
     """Write a sparse cut-site bigWig from 10x-style fragment intervals."""
 
-    if pyBigWig is None:
-        raise RuntimeError("pyBigWig is required for --write-cutsite-bigwigs")
     genome = load_genome_sizes(genome_sizes)
     chrom_sizes = dict(genome)
     counts: dict[str, dict[int, int]] = defaultdict(lambda: defaultdict(int))
@@ -283,7 +279,19 @@ def group_bam_by_tag(
     """Split a tagged all-cell BAM into sorted pseudobulk BAMs by annotation group."""
 
     if pysam is None:
-        raise RuntimeError("pysam is required for BAM pseudobulk splitting")
+        return _group_bam_to_fragments_portable(
+            bam,
+            annotations,
+            outdir,
+            group_by,
+            barcode_column=barcode_column,
+            barcode_tag=barcode_tag,
+            min_cells=min_cells,
+            min_fragments=min_fragments,
+            strip_barcode_suffix=strip_barcode_suffix,
+            include_chroms=include_chroms,
+            exclude_chroms=exclude_chroms,
+        )
     outdir = Path(outdir)
     outdir.mkdir(parents=True, exist_ok=True)
     cores = multiprocessing.cpu_count() if cores is None else max(1, int(cores))
@@ -372,6 +380,106 @@ def group_bam_by_tag(
     }
     with (outdir / "fp_tools_manifest.yml").open("w", encoding="utf-8") as handle:
         yaml.safe_dump(config, handle, sort_keys=False)
+    return manifest
+
+
+def _group_bam_to_fragments_portable(
+    bam: str | Path,
+    annotations: str | Path,
+    outdir: str | Path,
+    group_by: list[str],
+    *,
+    barcode_column: str,
+    barcode_tag: str,
+    min_cells: int,
+    min_fragments: int,
+    strip_barcode_suffix: bool,
+    include_chroms: set[str] | None,
+    exclude_chroms: set[str] | None,
+) -> pd.DataFrame:
+    """Convert a tagged BAM to grouped fragments using the Windows BAM reader."""
+
+    outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    barcode_to_group = load_annotations(annotations, barcode_column, group_by, strip_barcode_suffix)
+    handles = {}
+    paths = {}
+    cells_by_group: dict[str, set[str]] = defaultdict(set)
+    fragments_by_group: dict[str, int] = defaultdict(int)
+    try:
+        with open_alignment(bam, "rb") as source:
+            for read in source.fetch(until_eof=True):
+                if read.is_unmapped or read.is_duplicate:
+                    continue
+                chrom = read.reference_name
+                if include_chroms is not None and chrom not in include_chroms:
+                    continue
+                if exclude_chroms is not None and chrom in exclude_chroms:
+                    continue
+                try:
+                    barcode = _normalize_barcode(read.get_tag(barcode_tag), strip_barcode_suffix)
+                except (AttributeError, KeyError):
+                    continue
+                group = barcode_to_group.get(barcode)
+                if group is None:
+                    continue
+                if getattr(read, "is_paired", False):
+                    if not getattr(read, "is_read1", False) or int(read.template_length) <= 0:
+                        continue
+                    start = int(read.reference_start)
+                    end = start + int(read.template_length)
+                else:
+                    start, end = int(read.reference_start), int(read.reference_end)
+                if end <= start:
+                    continue
+                if group not in handles:
+                    path = outdir / f"{group}.fragments.tsv"
+                    paths[group] = path
+                    handles[group] = path.open("w", encoding="utf-8")
+                handles[group].write(f"{chrom}\t{start}\t{end}\t{barcode}\t1\n")
+                cells_by_group[group].add(barcode)
+                fragments_by_group[group] += 1
+    finally:
+        for handle in handles.values():
+            handle.close()
+
+    rows = []
+    for group in sorted(paths):
+        cells = len(cells_by_group[group])
+        fragments = fragments_by_group[group]
+        keep = cells >= min_cells and fragments >= min_fragments
+        fragment_file = _compress_no_index(paths[group]) if keep else paths[group]
+        if not keep:
+            paths[group].unlink(missing_ok=True)
+        rows.append(
+            {
+                "group": group,
+                "fragment_file": str(fragment_file) if keep else "",
+                "n_cells": cells,
+                "n_fragments": fragments,
+                "n_reads": fragments * 2,
+                "cutsite_bigwig": "",
+                "pseudo_bam": "",
+                "passes_filters": keep,
+                "source_type": "fragments",
+                "read_shift": "0 0",
+            }
+        )
+    manifest = pd.DataFrame(rows)
+    manifest_path = outdir / "pseudobulk_manifest.tsv"
+    manifest.to_csv(manifest_path, sep="\t", index=False)
+    with (outdir / "fp_tools_manifest.yml").open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "pseudobulk_manifest": str(manifest_path),
+                "group_by": group_by,
+                "barcode_tag": barcode_tag,
+                "samples": [row for row in manifest.to_dict(orient="records") if row["passes_filters"]],
+            },
+            handle,
+            sort_keys=False,
+        )
     return manifest
 
 

--- a/src/fp_tools/tools/pseudobulk_footprints.py
+++ b/src/fp_tools/tools/pseudobulk_footprints.py
@@ -223,10 +223,10 @@ def _group_inputs(args: argparse.Namespace, grouping_dir: Path, include_chroms: 
         include_chroms=include_chroms,
         exclude_chroms=exclude_chroms,
         compress_output=True,
-        index_output=True,
+        index_output=False,
         genome_sizes=args.genome_sizes,
         write_cutsite_bigwigs=True,
-        write_pseudo_bams=True,
+        write_pseudo_bams=False,
         cpm_normalize=not args.no_cpm_normalize,
         cores=args.cores,
     )
@@ -298,8 +298,8 @@ def run_pseudobulk_footprints(args: argparse.Namespace) -> int:
 
         atac_command = [
             "atac-correct",
-            "--bams",
-            str(source["pseudo_bam"]),
+            "--fragments" if str(source.get("source_type", "")) == "fragments" else "--bams",
+            str(source["fragment_file"] if str(source.get("source_type", "")) == "fragments" else source["pseudo_bam"]),
             "--genome",
             str(args.genome),
             "--peaks",
@@ -479,7 +479,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--annotations", required=True, help="Cell annotation TSV or CSV.")
     parser.add_argument("--group-by", required=True, help="Comma-separated annotation columns to group by.")
     parser.add_argument("--outdir", required=True, help="Output directory for the full pseudobulk footprint workflow.")
-    parser.add_argument("--genome-sizes", help="Two-column chromosome sizes file; required for fragment input cut-site bigWigs and pseudo-BAMs.")
+    parser.add_argument("--genome-sizes", help="Two-column chromosome sizes file used for fragment-derived cut-site bigWigs.")
     parser.add_argument("--genome", required=True, help="Genome FASTA for atac-correct.")
     parser.add_argument("--peaks", required=True, help="Peak BED used for atac-correct and footprint scoring.")
     parser.add_argument("--blacklist", help="Optional blacklist BED for atac-correct.")
@@ -493,7 +493,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--min-fragments", type=int, default=1, help="Minimum fragments/reads for passes_filters (default: 1).")
     parser.add_argument("--no-cpm-normalize", action="store_true", help="Write raw cut counts instead of CPM-normalized cut-site bigWigs for fragment input.")
     parser.add_argument("--top-n", type=int, default=None, help="Optional top N candidate footprints per group.")
-    parser.add_argument("--read-shift", nargs=2, type=int, metavar=("FWD", "REV"), help="Override the atac-correct read shift for fragment-derived pseudo-BAMs (default: 0 0).")
+    parser.add_argument("--read-shift", nargs=2, type=int, metavar=("FWD", "REV"), help="Override the atac-correct read shift for fragment cut sites (default: 0 0).")
     parser.add_argument("--motifs", nargs="*", help="Optional motif file(s); when provided, run motif-aware diff-footprints on pseudobulk footprint tracks.")
     parser.add_argument("--motif-db", default=DEFAULT_MOTIF_DB, help=f"Built-in motif database for motif matching (default: {DEFAULT_MOTIF_DB}); can be combined with --motifs.")
     parser.add_argument("--list-motif-dbs", action="store_true", help="List available built-in motif databases and exit.")

--- a/src/fp_tools/tools/score_bigwig.py
+++ b/src/fp_tools/tools/score_bigwig.py
@@ -14,7 +14,7 @@ import argparse
 import copy
 import bisect
 import numpy as np
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 import multiprocessing as mp
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from contextlib import closing

--- a/src/fp_tools/tools/tfbs_features.py
+++ b/src/fp_tools/tools/tfbs_features.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 
 from fp_tools.tools.motif_discovery import CandidateSite, load_genome_fasta, read_candidate_sites
 

--- a/src/fp_tools/utils/alignment.py
+++ b/src/fp_tools/utils/alignment.py
@@ -1,0 +1,252 @@
+"""Cross-platform read-only BAM access used by core footprinting commands."""
+
+from __future__ import annotations
+
+import os
+import gzip
+from dataclasses import dataclass
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import pysam as _pysam
+except ImportError:  # pragma: no cover - Windows path
+    _pysam = None
+
+try:
+    import bamnostic as _bamnostic
+except ImportError:  # pragma: no cover - dependency metadata installs it
+    _bamnostic = None
+
+
+def backend_name() -> str:
+    return "pysam" if _pysam is not None else "bamnostic"
+
+
+def open_alignment(path: str | os.PathLike[str], mode: str = "rb"):
+    """Open a BAM for reading with normalized record attributes."""
+
+    path_text = str(path)
+    if path_text.endswith((".tsv", ".tsv.gz", ".fragments", ".fragments.gz")):
+        return FragmentAlignment(path_text)
+    if mode not in {"r", "rb"}:
+        if _pysam is None:
+            raise RuntimeError("Writing BAM files requires pysam; use fragment input on Windows")
+        return _pysam.AlignmentFile(str(path), mode)
+    if _pysam is not None:
+        return _pysam.AlignmentFile(str(path), mode)
+    if _bamnostic is None:
+        raise ImportError("BAM support requires pysam or bamnostic")
+    return _BamnosticAlignment(str(path))
+
+
+def _open_text(path: str):
+    return gzip.open(path, "rt", encoding="utf-8") if path.endswith(".gz") else open(path, encoding="utf-8")
+
+
+@dataclass
+class _FragmentRecord:
+    reference_name: str
+    reference_start: int
+    reference_end: int
+    is_reverse: bool
+    query_name: str
+    template_length: int
+    flag: int
+    reference_id: int
+    query_alignment_start: int = 0
+    query_alignment_end: int = 1
+    query_length: int = 1
+    cigartuples: tuple[tuple[int, int], ...] = ((0, 1),)
+    is_unmapped: bool = False
+    is_duplicate: bool = False
+
+    def get_tags(self):
+        return []
+
+    def infer_query_length(self):
+        return self.query_length
+
+
+class FragmentAlignment:
+    """Read 10x-style fragments as paired one-base cut-site anchors."""
+
+    def __init__(self, path: str):
+        self.path = str(Path(path).expanduser().resolve())
+        self.filename = self.path.encode("utf-8")
+        raw: dict[str, list[tuple[int, int, int]]] = defaultdict(list)
+        lengths: dict[str, int] = {}
+        with _open_text(self.path) as handle:
+            for line in handle:
+                if not line.strip() or line.startswith("#"):
+                    continue
+                fields = line.rstrip("\n").split("\t")
+                if len(fields) < 3:
+                    continue
+                chrom, start, end = fields[0], int(fields[1]), int(fields[2])
+                if end - start < 2:
+                    continue
+                copies = int(fields[4]) if len(fields) > 4 and fields[4].isdigit() else 1
+                raw[chrom].append((start, end, copies))
+                lengths[chrom] = max(lengths.get(chrom, 0), end)
+        self.references = tuple(raw)
+        self.lengths = tuple(lengths[chrom] for chrom in self.references)
+        self._reference_ids = {chrom: index for index, chrom in enumerate(self.references)}
+        self._raw = raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def close(self):
+        return None
+
+    def has_index(self):
+        return True
+
+    def check_index(self):
+        return True
+
+    def get_reference_name(self, reference_id: int) -> str:
+        return self.references[int(reference_id)]
+
+    def _records(self, chrom: str, start: int, end: int):
+        ref_id = self._reference_ids[chrom]
+        for row_index, (fragment_start, fragment_end, copies) in enumerate(self._raw.get(chrom, [])):
+            if fragment_start >= end or fragment_end <= start:
+                continue
+            reverse_start = fragment_end - 2
+            template_length = fragment_end - fragment_start
+            for copy_index in range(copies):
+                name = f"{chrom}:{fragment_start}-{fragment_end}:{row_index}:{copy_index}"
+                yield _FragmentRecord(
+                    chrom, fragment_start, fragment_start + 1, False, name,
+                    template_length, 99, ref_id,
+                )
+                yield _FragmentRecord(
+                    chrom, reverse_start, reverse_start + 1, True, name,
+                    -template_length, 147, ref_id,
+                )
+
+    def fetch(self, reference=None, start=None, end=None, until_eof=False):
+        if until_eof:
+            for chrom, chrom_length in zip(self.references, self.lengths):
+                yield from self._records(chrom, 0, chrom_length)
+            return
+        if reference not in self._raw:
+            return
+        yield from self._records(reference, int(start or 0), int(end or self.lengths[self._reference_ids[reference]]))
+
+
+def index_alignment(path: str | os.PathLike[str]) -> bool:
+    """Create a BAM index when pysam is available; otherwise use scan fallback."""
+
+    if _pysam is None:
+        return False
+    _pysam.index(str(path))
+    return True
+
+
+class _BamnosticRecord:
+    def __init__(self, record):
+        self._record = record
+
+    def __getattr__(self, name):
+        if name == "template_length":
+            return self._record.tlen
+        if name == "query_alignment_start":
+            total = 0
+            for operation, size in (self._record.cigartuples or []):
+                if operation == 4:
+                    total += int(size)
+                elif operation != 5:
+                    break
+            return total
+        if name == "query_alignment_end":
+            start = self.query_alignment_start
+            length = sum(
+                int(size)
+                for operation, size in (self._record.cigartuples or [])
+                if operation in {0, 1, 7, 8}
+            )
+            return start + length
+        if name == "query_alignment_length":
+            return self.query_alignment_end - self.query_alignment_start
+        if name == "infer_query_length":
+            return lambda: int(getattr(self._record, "query_length", 0) or self.query_alignment_end)
+        return getattr(self._record, name)
+
+
+class _BamnosticAlignment:
+    """bamnostic reader with an indexed-query or one-pass in-memory fallback."""
+
+    def __init__(self, path: str):
+        self.path = str(Path(path).expanduser().resolve())
+        self.filename = self.path.encode("utf-8")
+        self._handle = _bamnostic.AlignmentFile(self.path, "rb", require_index=False)
+        self.references = tuple(self._handle.references)
+        self.lengths = tuple(self._handle.lengths)
+        self._cache = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+        return False
+
+    def __iter__(self):
+        for record in self._handle:
+            yield _BamnosticRecord(record)
+
+    def close(self):
+        self._handle.close()
+
+    def has_index(self) -> bool:
+        try:
+            return bool(self._handle.check_index())
+        except (AttributeError, OSError, ValueError):
+            return False
+
+    def check_index(self):
+        if not self.has_index():
+            raise ValueError("BAM index is not available")
+        return True
+
+    def get_reference_name(self, reference_id: int) -> str:
+        return self.references[int(reference_id)]
+
+    def fetch(self, reference=None, start=None, end=None, until_eof=False):
+        if until_eof:
+            fresh = _bamnostic.AlignmentFile(self.path, "rb", require_index=False)
+            try:
+                for record in fresh:
+                    yield _BamnosticRecord(record)
+            finally:
+                fresh.close()
+            return
+        if reference is None:
+            raise ValueError("reference is required unless until_eof=True")
+        try:
+            for record in self._handle.fetch(reference, int(start or 0), int(end or self.lengths[self.references.index(reference)])):
+                yield _BamnosticRecord(record)
+            return
+        except (AttributeError, OSError, ValueError):
+            pass
+        if self._cache is None:
+            grouped = defaultdict(list)
+            fresh = _bamnostic.AlignmentFile(self.path, "rb", require_index=False)
+            try:
+                for record in fresh:
+                    if not record.is_unmapped:
+                        grouped[record.reference_name].append(_BamnosticRecord(record))
+            finally:
+                fresh.close()
+            self._cache = grouped
+        lo = int(start or 0)
+        hi = int(end if end is not None else self.lengths[self.references.index(reference)])
+        for record in self._cache.get(reference, []):
+            if record.reference_start < hi and record.reference_end > lo:
+                yield record

--- a/src/fp_tools/utils/bigwig.py
+++ b/src/fp_tools/utils/bigwig.py
@@ -1,0 +1,217 @@
+"""Cross-platform bigWig I/O with a small pyBigWig-compatible surface.
+
+``pyBigWig`` is used when it is available.  Other platforms use
+``pybigtools``, whose wheels cover Windows, macOS, and Linux.  The adapter is
+deliberately limited to the methods used by fp-tools so scientific code does
+not need platform checks.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import queue
+import threading
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+# pyBigWig exposes this feature flag and legacy code uses it to request arrays.
+numpy = 1
+
+try:  # Fast native backend on platforms where a wheel is available.
+    import pyBigWig as _pybigwig
+except ImportError:  # pragma: no cover - exercised on Windows/macOS CI
+    _pybigwig = None
+
+try:
+    import pybigtools as _pybigtools
+except ImportError:  # pragma: no cover - dependency metadata installs it
+    _pybigtools = None
+
+
+def backend_name() -> str:
+    """Return the selected bigWig backend name."""
+
+    return "pyBigWig" if _pybigwig is not None else "pybigtools"
+
+
+def open(path: str | os.PathLike[str], mode: str = "r"):  # noqa: A001 - API compatibility
+    """Open a bigWig file using the best available backend."""
+
+    path = str(path)
+    normalized_mode = mode.replace("b", "")
+    if _pybigwig is not None:
+        return _pybigwig.open(path, normalized_mode)
+    if _pybigtools is None:
+        raise ImportError("bigWig support requires pybigtools or pyBigWig")
+    if normalized_mode.startswith("w"):
+        return _StreamingBigWigWriter(path)
+    return _BigWigReader(path)
+
+
+class _BigWigReader:
+    def __init__(self, path: str):
+        self.path = path
+        self._handle = _pybigtools.open(path)
+
+    def __bool__(self) -> bool:
+        return self._handle is not None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+        return False
+
+    def close(self) -> None:
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    def chroms(self, chrom: str | None = None):
+        result = dict(self._handle.chroms())
+        return result.get(chrom) if chrom is not None else result
+
+    def values(self, chrom: str, start: int, end: int, numpy: bool = False):
+        values = list(self._handle.values(chrom, int(start), int(end), fillna=None))
+        return np.asarray(values, dtype=float) if numpy else values
+
+    def intervals(self, chrom: str, start: int | None = None, end: int | None = None):
+        chrom_size = self.chroms(chrom)
+        if chrom_size is None:
+            return None
+        lo = 0 if start is None else max(0, int(start))
+        hi = int(chrom_size) if end is None else min(int(chrom_size), int(end))
+        records = list(self._handle.records(chrom, lo, hi))
+        return records or None
+
+    def stats(
+        self,
+        chrom: str,
+        start: int,
+        end: int,
+        type: str = "mean",  # noqa: A002 - pyBigWig API compatibility
+        nBins: int = 1,
+        **_kwargs,
+    ):
+        if type not in {"mean", "min", "max", "sum", "coverage", "std"}:
+            raise ValueError(f"Unsupported bigWig summary type: {type}")
+        edges = np.linspace(int(start), int(end), max(1, int(nBins)) + 1, dtype=int)
+        summaries = []
+        for left, right in zip(edges[:-1], edges[1:]):
+            values = np.asarray(self.values(chrom, int(left), int(right), numpy=True), dtype=float)
+            finite = values[np.isfinite(values)]
+            if finite.size == 0:
+                summaries.append(None)
+            elif type == "mean":
+                summaries.append(float(np.mean(finite)))
+            elif type == "min":
+                summaries.append(float(np.min(finite)))
+            elif type == "max":
+                summaries.append(float(np.max(finite)))
+            elif type == "sum":
+                summaries.append(float(np.sum(finite)))
+            elif type == "std":
+                summaries.append(float(np.std(finite)))
+            else:
+                summaries.append(float(finite.size / max(1, right - left)))
+        return summaries
+
+
+class _StreamingBigWigWriter:
+    """Feed incremental pyBigWig-style entries to a pybigtools writer."""
+
+    def __init__(self, path: str):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._header: dict[str, int] | None = None
+        self._queue = queue.Queue(maxsize=100_000)
+        self._sentinel = object()
+        self._thread = None
+        self._error = None
+        self._closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        if exc_type is None:
+            self.close()
+        else:
+            self._finish()
+        return False
+
+    def addHeader(self, header: Iterable[tuple[str, int]], **_kwargs) -> None:
+        self._header = {str(chrom): int(size) for chrom, size in header}
+        self._thread = threading.Thread(target=self._write, daemon=True)
+        self._thread.start()
+
+    def _write(self) -> None:
+        try:
+            writer = _pybigtools.open(str(self.path), "w")
+            writer.write(self._header, self._records())
+        except Exception as exc:  # surfaced in close/addEntries
+            self._error = exc
+
+    def addEntries(self, chroms, starts, ends=None, values=None, span=1, **_kwargs) -> None:
+        if isinstance(chroms, str):
+            if isinstance(starts, (int, np.integer)):
+                starts = [int(starts)]
+            chrom_values = [chroms] * len(starts)
+        else:
+            chrom_values = list(chroms)
+            starts = list(starts)
+        if values is None:
+            raise ValueError("values are required when writing bigWig entries")
+        values = list(values)
+        if ends is None:
+            end_values = [int(start) + int(span) for start in starts]
+        else:
+            end_values = list(ends)
+        if not (len(chrom_values) == len(starts) == len(end_values) == len(values)):
+            raise ValueError("chroms, starts, ends, and values must have equal lengths")
+        for chrom, start, end, value in zip(chrom_values, starts, end_values, values):
+            numeric = float(value)
+            if math.isfinite(numeric):
+                record = (str(chrom), int(start), int(end), numeric)
+                while True:
+                    if self._error is not None:
+                        raise RuntimeError("pybigtools writer failed") from self._error
+                    try:
+                        self._queue.put(record, timeout=0.2)
+                        break
+                    except queue.Full:
+                        continue
+
+    def _records(self):
+        while True:
+            record = self._queue.get()
+            if record is self._sentinel:
+                return
+            yield record
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if self._header is None:
+            raise ValueError("addHeader must be called before closing a bigWig writer")
+        self._finish()
+        if self._error is not None:
+            raise RuntimeError("pybigtools writer failed") from self._error
+        self._closed = True
+
+    def _finish(self) -> None:
+        if self._thread is None:
+            return
+        while self._thread.is_alive():
+            try:
+                self._queue.put(self._sentinel, timeout=0.2)
+                break
+            except queue.Full:
+                if self._error is not None:
+                    break
+        self._thread.join()
+        self._thread = None

--- a/src/fp_tools/utils/fasta.py
+++ b/src/fp_tools/utils/fasta.py
@@ -1,0 +1,74 @@
+"""Indexed FASTA access that keeps generated indexes outside source data."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pyfastx
+
+try:
+    import pysam
+except ImportError:  # pragma: no cover - Windows path
+    pysam = None
+
+
+def _cache_root() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    path = base / "fp-tools" / "fasta"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+class FastaFile:
+    """Subset of :class:`pysam.FastaFile` used by fp-tools."""
+
+    def __init__(self, path: str | os.PathLike[str]):
+        self.filename = str(Path(path).expanduser().resolve())
+        if pysam is not None:
+            self.index_path = None
+            self._fasta = pysam.FastaFile(self.filename)
+            self._pysam = True
+            return
+        source = Path(self.filename)
+        identity = f"{self.filename}:{source.stat().st_size}:{source.stat().st_mtime_ns}"
+        index_name = hashlib.sha256(identity.encode("utf-8")).hexdigest() + ".fxi"
+        self.index_path = _cache_root() / index_name
+        self._fasta = pyfastx.Fasta(self.filename, index_file=str(self.index_path), full_name=False)
+        self._pysam = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+        return False
+
+    @property
+    def references(self) -> tuple[str, ...]:
+        return tuple(self._fasta.references) if self._pysam else tuple(self._fasta.keys())
+
+    @property
+    def lengths(self) -> tuple[int, ...]:
+        return tuple(self._fasta.lengths) if self._pysam else tuple(len(self._fasta[name]) for name in self.references)
+
+    def fetch(self, reference: str, start: int | None = None, end: int | None = None) -> str:
+        if self._pysam:
+            return str(self._fasta.fetch(str(reference), start, end))
+        record = self._fasta[str(reference)]
+        lo = 0 if start is None else int(start)
+        hi = len(record) if end is None else int(end)
+        return str(record[lo:hi])
+
+    def close(self) -> None:
+        if self._pysam and self._fasta is not None:
+            self._fasta.close()
+        self._fasta = None
+
+
+def open_fasta(path: str | os.PathLike[str]) -> FastaFile:
+    return FastaFile(path)

--- a/src/fp_tools/utils/intervals.py
+++ b/src/fp_tools/utils/intervals.py
@@ -1,0 +1,87 @@
+"""Small, dependency-free BED interval overlap helpers."""
+
+from __future__ import annotations
+
+import bisect
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+def _iter_bed(path: str | Path) -> Iterator[tuple[str, int, int, str]]:
+    with Path(path).open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip() or line.startswith(("#", "track", "browser")):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 3:
+                continue
+            try:
+                yield fields[0], int(fields[1]), int(fields[2]), line
+            except ValueError:
+                continue
+
+
+class IntervalIndex:
+    """Chromosome-partitioned interval index for overlap membership queries."""
+
+    def __init__(self, intervals: Iterable[tuple[str, int, int]] = ()):
+        grouped: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        for chrom, start, end in intervals:
+            if end > start:
+                grouped[str(chrom)].append((int(start), int(end)))
+        self._intervals: dict[str, tuple[list[int], list[int]]] = {}
+        for chrom, values in grouped.items():
+            values.sort()
+            merged: list[list[int]] = []
+            for start, end in values:
+                if merged and start <= merged[-1][1]:
+                    merged[-1][1] = max(merged[-1][1], end)
+                else:
+                    merged.append([start, end])
+            self._intervals[chrom] = (
+                [item[0] for item in merged],
+                [item[1] for item in merged],
+            )
+
+    @classmethod
+    def from_bed(cls, path: str | Path) -> "IntervalIndex":
+        return cls((chrom, start, end) for chrom, start, end, _line in _iter_bed(path))
+
+    def overlaps(self, chrom: str, start: int, end: int) -> bool:
+        starts, ends = self._intervals.get(str(chrom), ([], []))
+        if not starts or end <= start:
+            return False
+        index = bisect.bisect_left(starts, int(end)) - 1
+        return index >= 0 and ends[index] > int(start)
+
+
+def intersect_bed(
+    query: str | Path,
+    regions: str | Path,
+    output: str | Path,
+    *,
+    invert: bool = False,
+) -> Path:
+    """Write query BED records that overlap (or do not overlap) regions."""
+
+    index = IntervalIndex.from_bed(regions)
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as handle:
+        for chrom, start, end, line in _iter_bed(query):
+            keep = index.overlaps(chrom, start, end)
+            if keep != invert:
+                handle.write(line if line.endswith("\n") else line + "\n")
+    return output
+
+
+def filter_regions(region_list, regions: str | Path, *, invert: bool = False):
+    """Return a RegionList-like object filtered by overlap membership."""
+
+    index = IntervalIndex.from_bed(regions)
+    return region_list.__class__(
+        region
+        for region in region_list
+        if index.overlaps(region.chrom, region.start, region.end) != invert
+    )

--- a/src/fp_tools/utils/logger.py
+++ b/src/fp_tools/utils/logger.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import logging
 import logging.handlers
 import multiprocessing as mp
+import threading
 import time
 from importlib.metadata import PackageNotFoundError, version as package_version
 
@@ -114,7 +115,13 @@ class FpToolsLogger(logging.Logger):
     def start_logger_queue(self):
         self.debug("Starting logger queue for multiprocessing")
         self.queue = mp.Manager().Queue()
-        self.listener = mp.Process(target=self.main_logger_process)
+        # A thread can consume records produced by spawned worker processes
+        # without requiring the logger itself to be pickled on macOS/Windows.
+        self.listener = threading.Thread(
+            target=self.main_logger_process,
+            name=f"{self.tool_name}-log-listener",
+            daemon=True,
+        )
         self.listener.start()
 
     def stop_logger_queue(self):
@@ -127,10 +134,8 @@ class FpToolsLogger(logging.Logger):
         if self.listener is not None:
             self.listener.join(timeout=5)
             if self.listener.is_alive():
-                self.warning("Multiprocessing logger did not stop promptly; terminating listener.")
-                self.listener.terminate()
-                self.listener.join(timeout=2)
-            self.debug(f"Logger listener exitcode is: {self.listener.exitcode}")
+                self.warning("Multiprocessing logger did not stop promptly.")
+            self.debug(f"Logger listener is alive: {self.listener.is_alive()}")
 
     def main_logger_process(self):
         self.debug("Started main logger process")

--- a/src/fp_tools/utils/motifs.py
+++ b/src/fp_tools/utils/motifs.py
@@ -43,17 +43,95 @@ except Exception as e:
         "biopython is required for reading/writing motifs. Install with: `poetry add biopython`"
     ) from e
 
-try:  # fast scanning
+try:  # fast scanning when the legacy extension is available
     import MOODS.scan  # type: ignore
     import MOODS.tools  # type: ignore
     import MOODS.parsers  # type: ignore
-except Exception as e:  # pragma: no cover
-    raise ImportError(
-        "MOODS is required for motif scanning. Install with: `poetry add MOODS-python==1.9.4.1`"
-    ) from e
+    _HAVE_MOODS = True
+except Exception:  # Cross-platform NumPy fallback is used on Windows.
+    MOODS = None
+    _HAVE_MOODS = False
 
 # --- Internal (fp_tools namespace) ----------------------------------------
 from fp_tools.utils.regions import OneRegion, RegionList
+
+
+class _ScanMatch:
+    def __init__(self, pos: int, score: float):
+        self.pos = pos
+        self.score = score
+
+
+class _NumpyMotifScanner:
+    """MOODS-compatible scanner for the fp-tools DNA alphabet (A,C,G,T)."""
+
+    def set_motifs(self, matrices, background, thresholds):
+        self.matrices = [np.asarray(matrix, dtype=float) for matrix in matrices]
+        self.thresholds = [float(value) for value in thresholds]
+
+    def scan(self, sequence: str):
+        lookup = np.full(256, -1, dtype=np.int8)
+        for index, base in enumerate(b"ACGT"):
+            lookup[base] = lookup[base + 32] = index
+        encoded = lookup[np.frombuffer(sequence.encode("ascii", errors="replace"), dtype=np.uint8)]
+        output = []
+        for matrix, threshold in zip(self.matrices, self.thresholds):
+            width = matrix.shape[1]
+            count = encoded.size - width + 1
+            if count <= 0:
+                output.append([])
+                continue
+            scores = np.zeros(count, dtype=float)
+            valid = np.ones(count, dtype=bool)
+            for offset in range(width):
+                bases = encoded[offset:offset + count]
+                valid &= bases >= 0
+                safe = np.where(bases >= 0, bases, 0)
+                scores += matrix[safe, offset]
+            positions = np.flatnonzero(valid & (scores >= threshold))
+            output.append([_ScanMatch(int(pos), float(scores[pos])) for pos in positions])
+        return output
+
+
+def _threshold_from_p(pssm: np.ndarray, background: np.ndarray, pvalue: float) -> float:
+    if _HAVE_MOODS:
+        pssm_tuple = tuple(tuple(float(value) for value in row) for row in pssm)
+        return float(MOODS.tools.threshold_from_p(pssm_tuple, background, pvalue, 4))
+    # Exact Python translation of MOODS threshold_from_p_with_precision for a
+    # first-order DNA PSSM (the upstream default DP precision is 2,000).
+    precision = 2_000.0
+    scaled = precision * np.asarray(pssm, dtype=float)
+    integer = np.where(scaled > 0.0, np.floor(scaled + 0.5), np.ceil(scaled - 0.5)).astype(np.int64)
+    width = integer.shape[1]
+    column_max = integer.max(axis=0)
+    minimum_value = int(integer.min())
+    max_total = int(column_max.sum())
+    score_range = max_total - width * minimum_value
+    current = np.zeros(score_range + 1, dtype=float)
+    following = np.zeros(score_range + 1, dtype=float)
+    for base in range(integer.shape[0]):
+        current[int(integer[base, 0] - minimum_value)] += float(background[base])
+    for position in range(1, width):
+        for base in range(integer.shape[0]):
+            shift = int(integer[base, position] - minimum_value)
+            following[shift:] += float(background[base]) * current[:score_range + 1 - shift]
+        current, following = following, current
+        following.fill(0.0)
+    tail = float(current[score_range])
+    if tail > pvalue:
+        maxima = np.max(pssm, axis=0)
+        deltas = []
+        for column in np.asarray(pssm, dtype=float).T:
+            unique = np.unique(column)
+            if unique.size > 1:
+                deltas.append(float(unique[-1] - unique[-2]))
+        min_delta = min(deltas) if deltas else 0.0
+        return float(np.sum(maxima) - min_delta / 2.0)
+    for score_index in range(score_range - 1, -1, -1):
+        tail += float(current[score_index])
+        if tail > pvalue:
+            return float((score_index + width * minimum_value + 1) / precision)
+    return float(np.sum(np.min(pssm, axis=0)) - 1.0)
 
 # We try to import helpers from your utilities, but also provide local
 # fallbacks so this module works out-of-the-box.
@@ -329,7 +407,7 @@ class MotifList(list):
             parameters["names"].append(motif.prefix)
             parameters["matrices"].append(motif.pssm)
             parameters["thresholds"].append(motif.threshold)
-        scanner = MOODS.scan.Scanner(7)
+        scanner = MOODS.scan.Scanner(7) if _HAVE_MOODS else _NumpyMotifScanner()
         scanner.set_motifs(parameters["matrices"], motifs.bg, parameters["thresholds"])  # type: ignore[attr-defined]
         return (scanner, parameters)
 
@@ -641,8 +719,7 @@ class OneMotif:
     def get_threshold(self, pvalue: float = 1e-4) -> "OneMotif":
         if self.pssm is None:
             self.get_pssm()
-        pssm_tuple = tuple([tuple(row) for row in self.pssm])
-        self.threshold = MOODS.tools.threshold_from_p(pssm_tuple, self.bg, pvalue, 4)
+        self.threshold = _threshold_from_p(np.asarray(self.pssm, dtype=float), np.asarray(self.bg, dtype=float), pvalue)
         return self
 
     # ------- metrics -------------------------------------------------------

--- a/src/fp_tools/utils/ngs.pyx
+++ b/src/fp_tools/utils/ngs.pyx
@@ -2,7 +2,7 @@
 
 """Classes for working with NGS data such as reads and read lists."""
 
-import pysam
+from fp_tools.utils.alignment import index_alignment, open_alignment
 from collections import Counter
 
 import time
@@ -38,10 +38,10 @@ def index_bam(bam_obj, logger=None):
 	except ValueError:
 		logger.warn("Alignment file <{0}> has no .bai-index. Creating one now.".format(filename))
 
-		pysam.index(filename, filename + ".bai")
+		index_alignment(filename)
 		logger.info("Succesfully created index: {0}".format(filename + ".bai"))
 
-		bam_obj = pysam.AlignmentFile(filename)	#open bam again to include index 
+		bam_obj = open_alignment(filename)	#open bam again to include index
 
 	return(bam_obj)
 

--- a/src/fp_tools/utils/regions.py
+++ b/src/fp_tools/utils/regions.py
@@ -6,7 +6,7 @@ import numpy as np
 import sys
 import re
 from copy import deepcopy
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 from collections import Counter
 import logging
 import traceback

--- a/src/fp_tools/utils/sequences.pyx
+++ b/src/fp_tools/utils/sequences.pyx
@@ -8,7 +8,7 @@ import cython
 from libc.math cimport log2
 import sys
 
-import pysam
+from fp_tools.utils.fasta import open_fasta
 complement = {0:1, 1:0, 2:3, 3:2}
 
 
@@ -425,7 +425,7 @@ def get_gc_content(regions, fasta):
 	""" Get GC content from regions in fasta """
 	gc = 0
 	total = 0
-	fasta_obj = pysam.FastaFile(fasta)
+	fasta_obj = open_fasta(fasta)
 	for region in regions:
 		seq = fasta_obj.fetch(region.chrom, region.start, region.end)
 		gc += sum([1 for nuc in seq if (nuc == "G" or nuc == "g" or nuc == "C" or nuc == "c")])

--- a/src/fp_tools/utils/utilities.py
+++ b/src/fp_tools/utils/utilities.py
@@ -17,7 +17,7 @@ import copy
 from difflib import SequenceMatcher
 import traceback
 
-import pyBigWig
+from fp_tools.utils import bigwig as pyBigWig
 from fp_tools.utils.logger import *
 
 

--- a/tests/test_cross_platform_io.py
+++ b/tests/test_cross_platform_io.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+import unittest
+import shutil
+import subprocess
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from fp_tools.utils import bigwig
+from fp_tools.utils.alignment import FragmentAlignment, _BamnosticRecord
+from fp_tools.utils.intervals import IntervalIndex, intersect_bed
+from fp_tools.utils.logger import FpToolsLogger
+from fp_tools.utils.motifs import MotifList, _NumpyMotifScanner, _threshold_from_p
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CrossPlatformIoTests(unittest.TestCase):
+    def test_logger_listener_does_not_require_pickling_logger(self):
+        logger = FpToolsLogger("portable-test", level=0)
+        logger.start_logger_queue()
+        self.assertIsInstance(logger.listener, threading.Thread)
+        logger.stop_logger_queue()
+        self.assertFalse(logger.listener.is_alive())
+
+    def test_bamnostic_record_normalizes_soft_clips_and_template_length(self):
+        class Raw:
+            cigartuples = [(4, 5), (0, 45)]
+            query_alignment_start = 0
+            query_alignment_end = 45
+            tlen = 78
+
+        record = _BamnosticRecord(Raw())
+        self.assertEqual(record.query_alignment_start, 5)
+        self.assertEqual(record.query_alignment_end, 50)
+        self.assertEqual(record.query_alignment_length, 45)
+        self.assertEqual(record.template_length, 78)
+
+    def test_pybigtools_reader_matches_native_backend(self):
+        source = ROOT / "test_data" / "Tcell_uncorrected.bw"
+        if bigwig._pybigwig is None:
+            self.skipTest("native pyBigWig comparison backend unavailable")
+        with bigwig.open(source) as handle:
+            chrom = next(iter(handle.chroms()))
+            expected = np.asarray(handle.values(chrom, 10_000, 11_000, numpy=True))
+        native = bigwig._pybigwig
+        try:
+            bigwig._pybigwig = None
+            with bigwig.open(source) as handle:
+                observed = np.asarray(handle.values(chrom, 10_000, 11_000, numpy=True))
+        finally:
+            bigwig._pybigwig = native
+        self.assertTrue(np.allclose(expected, observed, equal_nan=True))
+
+    def test_pybigtools_writer_supports_fp_tools_surface(self):
+        native = bigwig._pybigwig
+        try:
+            bigwig._pybigwig = None
+            with tempfile.TemporaryDirectory() as tmp:
+                output = Path(tmp) / "portable.bw"
+                writer = bigwig.open(output, "w")
+                writer.addHeader([("chr1", 20)])
+                writer.addEntries("chr1", [2, 8], values=[1.5, -2.0], span=1)
+                writer.close()
+                with bigwig.open(output) as reader:
+                    self.assertEqual(reader.chroms(), {"chr1": 20})
+                    self.assertEqual(reader.intervals("chr1"), [(2, 3, 1.5), (8, 9, -2.0)])
+        finally:
+            bigwig._pybigwig = native
+
+    def test_interval_index_and_bed_intersection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            query = tmp / "query.bed"
+            regions = tmp / "regions.bed"
+            output = tmp / "out.bed"
+            query.write_text("chr1\t0\t5\ta\nchr1\t10\t20\tb\nchr2\t0\t2\tc\n", encoding="utf-8")
+            regions.write_text("chr1\t4\t11\n", encoding="utf-8")
+            index = IntervalIndex.from_bed(regions)
+            self.assertTrue(index.overlaps("chr1", 0, 5))
+            self.assertFalse(index.overlaps("chr1", 11, 12))
+            intersect_bed(query, regions, output)
+            self.assertEqual(output.read_text(encoding="utf-8"), "chr1\t0\t5\ta\nchr1\t10\t20\tb\n")
+
+    def test_numpy_scanner_uses_frozen_moods_threshold(self):
+        motifs = MotifList().from_file(
+            str(ROOT / "src" / "fp_tools" / "resources" / "motifs" / "JASPAR2026_CORE_vertebrates_non-redundant_pfms_jaspar.txt")
+        )
+        motif = motifs[0]
+        motif.get_pssm()
+        threshold = _threshold_from_p(motif.pssm, motif.bg, 1e-4)
+        self.assertAlmostEqual(threshold, 7.310867122206648, places=12)
+        scanner = _NumpyMotifScanner()
+        scanner.set_motifs([motif.pssm], motif.bg, [threshold])
+        hits = scanner.scan("ACGT" * 50)[0]
+        self.assertTrue(all(hit.score >= threshold for hit in hits))
+
+    def test_fragment_alignment_emits_both_cutsite_anchors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "sample.fragments.tsv"
+            path.write_text("chr1\t10\t20\tcell\t2\n", encoding="utf-8")
+            alignment = FragmentAlignment(str(path))
+            records = list(alignment.fetch("chr1", 0, 30))
+            self.assertEqual(len(records), 4)
+            self.assertEqual([record.reference_start for record in records], [10, 18, 10, 18])
+            self.assertEqual([record.is_reverse for record in records], [False, True, False, True])
+
+    def test_fragment_native_atac_correct_smoke(self):
+        script_name = "atac-correct.exe" if os.name == "nt" else "atac-correct"
+        executable_path = Path(sys.executable).parent / script_name
+        executable = str(executable_path) if executable_path.exists() else shutil.which("atac-correct")
+        if executable is None:
+            self.skipTest("installed atac-correct console script is unavailable")
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            genome = tmp / "genome.fa"
+            genome.write_text(">chr1\n" + "ACGT" * 500 + "\n", encoding="utf-8")
+            peaks = tmp / "peaks.bed"
+            peak_rows = [(200, 400), (800, 1000), (1400, 1600)]
+            peaks.write_text(
+                "".join(f"chr1\t{start}\t{end}\n" for start, end in peak_rows),
+                encoding="utf-8",
+            )
+            fragments = tmp / "sample.fragments.tsv"
+            fragments.write_text(
+                "".join(
+                    f"chr1\t{start + 20 + index * 3}\t{start + 100 + index * 3}\tcell\t1\n"
+                    for start, _end in peak_rows
+                    for index in range(20)
+                ),
+                encoding="utf-8",
+            )
+            outdir = tmp / "out"
+            result = subprocess.run(
+                [
+                    executable,
+                    "--fragments", str(fragments),
+                    "--genome", str(genome),
+                    "--peaks", str(peaks),
+                    "--regions-in", str(peaks),
+                    "--regions-out", str(peaks),
+                    "--outdir", str(outdir),
+                    "--prefix", "fragment_test",
+                    "--write-tracks", "corrected",
+                    "--skip-qc",
+                    "--scale-corrected", "none",
+                    "--cores", "1",
+                    "--verbosity", "1",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = outdir / "fragment_test_corrected.bw"
+            self.assertTrue(output.is_file())
+            with bigwig.open(output) as handle:
+                self.assertEqual(handle.chroms(), {"chr1": 2000})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -70,21 +70,14 @@ class DocsEntryPointContractTest(unittest.TestCase):
         documented = _verify_help_commands(self.readme)
         self.assertFalse(documented & REMOVED_ALIASES)
 
-    def test_gui_extra_is_declared_and_documented(self):
+    def test_gui_is_included_in_standard_install(self):
         extras = self.data["project"].get("optional-dependencies", {})
         self.assertIn(
             "gui", extras, "Expected a [project.optional-dependencies] gui extra."
         )
-        self.assertTrue(
-            any("streamlit" in dep for dep in extras["gui"]),
-            "The gui extra should provide streamlit.",
-        )
-        self.assertNotIn(
-            "streamlit",
-            "\n".join(self.data["project"]["dependencies"]),
-            "streamlit should be an optional extra, not a core dependency.",
-        )
-        self.assertIn("fp-tools-bio[gui]", self.readme)
+        self.assertTrue(any("streamlit" in dep for dep in self.data["project"]["dependencies"]))
+        self.assertIn("python -m pip install fp-tools-bio", self.readme)
+        self.assertNotIn("fp-tools-bio[gui]", self.readme)
 
     def test_api_reference_is_command_manual(self):
         for command in self.public_scripts:

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from fp_tools.cli_gui import _access_urls, _startup_messages
+
+
+class GuiLauncherTests(unittest.TestCase):
+    def test_local_startup_explains_browser_and_ssh_access(self):
+        text = "\n".join(_startup_messages("127.0.0.1", 8891, Path("runs")))
+        self.assertIn("http://127.0.0.1:8891", text)
+        self.assertIn("ssh -N -L 8891:127.0.0.1:8891 USER@SERVER", text)
+        self.assertIn("Ctrl+C", text)
+
+    def test_network_mode_warns_about_authentication(self):
+        text = "\n".join(_startup_messages("0.0.0.0", 8891, Path("runs")))
+        self.assertIn("http://SERVER_IP:8891", text)
+        self.assertIn("does not add authentication", text)
+        self.assertEqual(
+            _access_urls("0.0.0.0", 8891),
+            ["http://127.0.0.1:8891", "http://SERVER_IP:8891"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pseudobulk.py
+++ b/tests/test_pseudobulk.py
@@ -524,7 +524,7 @@ class PseudobulkTest(unittest.TestCase):
             self.assertTrue(commands.exists())
             text = commands.read_text(encoding="utf-8")
             self.assertIn("atac-correct", text)
-            self.assertIn("--bams", text)
+            self.assertIn("--fragments", text)
             self.assertNotIn("--bam ", text)
             self.assertIn("--read_shift 0 0", text)
             self.assertIn("call-footprints", text)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -35,8 +35,9 @@ class ReleaseMetadataTest(unittest.TestCase):
             "unittest discover",
             "call-footprints --help",
             "diff-footprints --help",
-            "scripts/build_release.sh",
-            "auditwheel",
+            "cibuildwheel",
+            "Windows AMD64",
+            "macOS x86_64 and arm64",
             "manylinux",
             "twine check",
             "PyPI",
@@ -89,9 +90,12 @@ class ReleaseMetadataTest(unittest.TestCase):
         self.assertTrue((ROOT / "DEV_PLAN.md").is_file())
         self.assertFalse((ROOT / "GUI_PLAN.md").exists())
 
-    def test_publish_workflow_uses_token_and_repaired_wheels(self):
+    def test_publish_workflow_uses_token_and_cross_platform_wheels(self):
         workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
-        self.assertIn("auditwheel", workflow)
+        self.assertIn("pypa/cibuildwheel", workflow)
+        self.assertIn("CIBW_ARCHS_LINUX: x86_64 aarch64", workflow)
+        self.assertIn("CIBW_ARCHS_MACOS: x86_64 arm64", workflow)
+        self.assertIn("CIBW_ARCHS_WINDOWS: AMD64", workflow)
         self.assertIn("twine check", workflow)
         self.assertIn("twine upload", workflow)
         self.assertIn("TWINE_USERNAME: __token__", workflow)


### PR DESCRIPTION
## Summary

- make the standard `pip install fp-tools-bio` installation include the GUI and support Python 3.11–3.13 on Windows, macOS, and Linux
- add portable BigWig, BAM/fragment, FASTA, interval, and motif-scanning adapters while retaining native backends where available
- let `atac-correct` and the single-cell workflow consume 10x fragments directly, avoiding pseudo-BAM generation on Windows
- make GUI startup open the local browser by default and print explicit localhost, remote SSH-tunnel, and network-binding instructions
- build and test release wheels with cibuildwheel for Windows AMD64, macOS Intel/Apple Silicon, and Linux x86_64/ARM64
- document the platform boundary: processed BAM/fragment/bigWig/BED workflows are native; raw FASTQ preparation and external MEME programs use installed command-line tools or WSL on Windows

## Scientific and compatibility safeguards

- native pyBigWig output remains preferred where available; pybigtools provides the portable reader/writer fallback
- pysam remains preferred outside Windows; bamnostic and direct fragment input provide portable read access
- the NumPy motif scanner reproduces the MOODS threshold calculation used by the existing workflow
- GUI logic remains a thin wrapper over public commands and YAML configurations
- current command names and compatibility entry points remain available

## Validation

- `python -m unittest discover -s tests`: 349 passed, 10 skipped
- `mkdocs build --clean --strict`: passed
- `python -m pip check`: passed
- all 22 console-script help smoke tests: passed
- wheel and sdist build: passed
- `twine check`: passed
- fresh Python 3.12 environment installed the wheel with `--only-binary=:all:`; `pip check`, all console scripts, and version check passed

## Release note

This PR prepares `0.2.0rc1`. PyPI publication should remain gated on the complete GitHub wheel matrix.
