### PR TITLE
Fix containing interval peak merges

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc1
+version: 0.2.0rc2
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc1
+#      python -m pip install fp-tools-bio==0.2.0rc2
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc1}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc2}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc1"
+version = "0.2.0rc2"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -143,7 +143,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc1"
+version = "0.2.0rc2"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc1"
+__version__ = "0.2.0rc2"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/utils/regions.py
+++ b/src/fp_tools/utils/regions.py
@@ -335,7 +335,11 @@ class RegionList(list):
 
 
 	def merge(self, name=False): 	
-		""" Merge overlapping genomic regions. If name == True, regions will only be merged if the name is the same (used in count_overlaps) """
+		"""Merge overlapping regions into their geometric union.
+
+		Book-ended regions remain separate. If ``name`` is true, regions are
+		only merged when their names are identical (used in ``count_overlaps``).
+		"""
 
 		self.loc_sort()		#sort before overlapping
 		no = self.count()	#number of regions
@@ -356,8 +360,9 @@ class RegionList(list):
 					self[i].start = prev_start
 					self[i][1] = prev_start
 
-					self[i].end = curr_end
-					self[i][2] = curr_end
+					merged_end = max(prev_end, curr_end)
+					self[i].end = merged_end
+					self[i][2] = merged_end
 
 					del self[i-1]
 					no -= 1

--- a/tests/test_atacorrect_batch.py
+++ b/tests/test_atacorrect_batch.py
@@ -62,6 +62,24 @@ class AtacCorrectBatchTest(unittest.TestCase):
                 ["chr1\t1\t5", "chr1\t10\t25", "chr2\t2\t4"],
             )
 
+    def test_merge_peak_files_preserves_containing_peak_endpoint(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            peaks_a = tmp / "am173.bed"
+            peaks_b = tmp / "am166.bed"
+            peaks_a.write_text("chr1\t938517\t938672\n", encoding="utf-8")
+            peaks_b.write_text(
+                "chr1\t938523\t938666\nchr1\t938670\t938700\n",
+                encoding="utf-8",
+            )
+
+            merged = Path(_merge_peak_files([peaks_a, peaks_b], tmp / "out"))
+
+            self.assertEqual(
+                merged.read_text(encoding="utf-8").splitlines(),
+                ["chr1\t938517\t938700"],
+            )
+
     def test_multi_bam_dispatch_uses_sample_subdirectories(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,84 @@
+import unittest
+
+from fp_tools.utils.regions import OneRegion, RegionList
+
+
+class RegionListMergeTest(unittest.TestCase):
+    @staticmethod
+    def _coordinates(regions):
+        return [(region.chrom, region.start, region.end) for region in regions]
+
+    def test_contained_interval_preserves_outer_endpoint(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 10, "outer"]),
+                OneRegion(["chr1", 2, 8, "inner"]),
+            ]
+        )
+
+        regions.merge()
+
+        self.assertEqual(self._coordinates(regions), [("chr1", 0, 10)])
+
+    def test_identical_intervals_merge(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 10, "first"]),
+                OneRegion(["chr1", 0, 10, "second"]),
+            ]
+        )
+
+        regions.merge()
+
+        self.assertEqual(self._coordinates(regions), [("chr1", 0, 10)])
+
+    def test_contained_middle_interval_does_not_break_chained_overlap(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 10]),
+                OneRegion(["chr1", 2, 8]),
+                OneRegion(["chr1", 9, 12]),
+            ]
+        )
+
+        regions.merge()
+
+        self.assertEqual(self._coordinates(regions), [("chr1", 0, 12)])
+
+    def test_non_overlapping_and_bookended_intervals_remain_separate(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 5]),
+                OneRegion(["chr1", 5, 10]),
+                OneRegion(["chr1", 12, 15]),
+                OneRegion(["chr2", 0, 5]),
+            ]
+        )
+
+        regions.merge()
+
+        self.assertEqual(
+            self._coordinates(regions),
+            [
+                ("chr1", 0, 5),
+                ("chr1", 5, 10),
+                ("chr1", 12, 15),
+                ("chr2", 0, 5),
+            ],
+        )
+
+    def test_name_aware_merge_keeps_different_names_separate(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 10, "A"]),
+                OneRegion(["chr1", 2, 8, "B"]),
+            ]
+        )
+
+        regions.merge(name=True)
+
+        self.assertEqual(self._coordinates(regions), [("chr1", 0, 10), ("chr1", 2, 8)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve the farther endpoint when merging a containing interval
- retain the existing strict-overlap rule, so book-ended intervals remain separate
- document that merged coordinates are the geometric union
- add focused interval edge-case tests and an `_merge_peak_files()` regression using the reported am173/am166 containment pattern
- prepare patch release `0.2.0rc2`

## Root cause

`RegionList.merge()` copied the current interval's end unconditionally. Because location sorting places an outer interval before a contained interval, the shorter contained endpoint replaced the correct outer endpoint and could also break a later chained overlap.

## Impact

Peak unions produced by `atac-correct` and `bulk-footprinting` now retain the complete genomic span of overlapping inputs. Name-aware merging and the existing treatment of book-ended intervals are unchanged.

## Validation

- minimal reproducer returns `[("chr1", 0, 10)]`
- 358 full-suite tests passed; one intentional skip
- 29 focused and release-metadata tests passed
- all 21 public console commands passed smoke testing
- `pip check` passed
- wheel and source distribution built successfully and passed `twine check`

Closes #13
