### PR TITLE
Fix differential statistics and name-aware interval merges

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc3
+version: 0.2.0rc4
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc3
+#      python -m pip install fp-tools-bio==0.2.0rc4
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc3}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc4}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc3"
+version = "0.2.0rc4"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -143,7 +143,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc3"
+version = "0.2.0rc4"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc3"
+__version__ = "0.2.0rc4"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/tools/diff_footprint_helpers.py
+++ b/src/fp_tools/tools/diff_footprint_helpers.py
@@ -69,6 +69,14 @@ except (ImportError, ValueError):
 apply_pdf_style()
 
 
+def _finite_scale(*standard_deviations):
+    """Return a finite positive scale for standardized mean differences."""
+
+    values = [abs(float(value)) for value in standard_deviations if np.isfinite(value)]
+    scale = float(np.mean(values)) if values else 0.0
+    return max(scale, float(np.finfo(float).eps))
+
+
 def dict_to_tab(dict_list, fname, chosen_columns, header=False):
     out_str = ("\t".join(chosen_columns) + "\n") if header else ""
     out_str += "\n".join(["\t".join([str(line[c]) for c in chosen_columns]) for line in dict_list])
@@ -456,20 +464,24 @@ def process_tfbs(TF_name, args, log2fc_params, bed_rows=None):
             n_obs = len(observed_log2fcs)
 
             if obs_mean != bg_mean:
-                change = (obs_mean - bg_mean) / np.mean([obs_std, bg_std])
+                change = (obs_mean - bg_mean) / _finite_scale(obs_std, bg_std)
                 info_table.at[TF_name, base + "_change"] = np.round(change, 5)
+
+                np.random.seed(n_obs)
+                sample_changes = []
+                for _ in range(100):
+                    sample = scipy.stats.norm.rvs(bg_mean, bg_std, size=n_obs)
+                    sm, ss = float(np.mean(sample)), float(np.std(sample))
+                    sample_changes.append((sm - bg_mean) / _finite_scale(ss, bg_std))
+                ttest = scipy.stats.ttest_1samp(
+                    sample_changes,
+                    float(info_table.at[TF_name, base + "_change"]),
+                )
+                pvalue = float(ttest.pvalue)
+                info_table.at[TF_name, base + "_pvalue"] = pvalue if np.isfinite(pvalue) else 1.0
             else:
                 info_table.at[TF_name, base + "_change"] = 0
                 info_table.at[TF_name, base + "_pvalue"] = 1
-
-            np.random.seed(n_obs)
-            sample_changes = []
-            for _ in range(100):
-                sample = scipy.stats.norm.rvs(bg_mean, bg_std, size=n_obs)
-                sm, ss = float(np.mean(sample)), float(np.std(sample))
-                sample_changes.append((sm - bg_mean) / np.mean([ss, bg_std]))
-            ttest = scipy.stats.ttest_1samp(sample_changes, float(info_table.at[TF_name, base + "_change"]))
-            info_table.at[TF_name, base + "_pvalue"] = ttest[1]
 
             if write_per_motif_plots:
                 fig, ax = plt.subplots(1, 1)

--- a/src/fp_tools/utils/regions.py
+++ b/src/fp_tools/utils/regions.py
@@ -338,8 +338,24 @@ class RegionList(list):
 		"""Merge overlapping regions into their geometric union.
 
 		Book-ended regions remain separate. If ``name`` is true, regions are
-		only merged when their names are identical (used in ``count_overlaps``).
+		merged independently within each chromosome/name group before genomic
+		sorting is restored (used in ``count_overlaps``).
 		"""
+
+		if name:
+			grouped_regions = {}
+			for region in self:
+				grouped_regions.setdefault((region.chrom, region.name), []).append(region)
+
+			merged_regions = []
+			for regions in grouped_regions.values():
+				group = RegionList(regions)
+				group.merge(name=False)
+				merged_regions.extend(group)
+
+			self[:] = merged_regions
+			self.loc_sort()
+			return(self)
 
 		self.loc_sort()		#sort before overlapping
 		no = self.count()	#number of regions
@@ -351,12 +367,7 @@ class RegionList(list):
 			prev_chrom, prev_start, prev_end = self[i-1].chrom, self[i-1].start, self[i-1].end
 			curr_chrom, curr_start, curr_end = self[i].chrom, self[i].start, self[i].end
 
-			#Check naming
-			merge_flag = True
-			if name == True:
-				merge_flag = True if self[i-1].name == self[i].name else False
-
-			if curr_chrom == prev_chrom and curr_start < prev_end and merge_flag == True:		#if overlapping regions
+			if curr_chrom == prev_chrom and curr_start < prev_end:		#if overlapping regions
 					self[i].start = prev_start
 					self[i][1] = prev_start
 

--- a/tests/test_diff_footprint_statistics.py
+++ b/tests/test_diff_footprint_statistics.py
@@ -1,0 +1,71 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from fp_tools.tools import diff_footprint_helpers
+
+
+class DifferentialFootprintStatisticsTest(unittest.TestCase):
+    @staticmethod
+    def _args(outdir):
+        return SimpleNamespace(
+            verbosity=0,
+            log_q=None,
+            write_motif_outputs=False,
+            write_cache_motif_all=False,
+            aggregate_site_set="all",
+            aggregate_signals=None,
+            plot_aggregate="off",
+            tmp_tfbs_root=outdir,
+            outdir=outdir,
+            output_peaks=None,
+            cond_names=["A", "B"],
+            comparisons=[("A", "B")],
+            peak_header_list=[],
+            sample_names=["A_rep1", "B_rep1"],
+            normalization="none",
+            thresholds={"A": 0.0, "B": 0.0},
+            condition_samples={"A": ["A_rep1"], "B": ["B_rep1"]},
+            condition_replicates={"A": 1, "B": 1},
+            pseudo=1.0,
+            per_motif_plots=False,
+            skip_excel=True,
+            keep_tmp_tfbs_for_cache=False,
+        )
+
+    @staticmethod
+    def _row(start, a_score, b_score):
+        return ["chr1", start, start + 10, "TF1", 1, "+", a_score, b_score]
+
+    def test_equal_observed_and_background_means_keep_pvalue_one(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rows = [self._row(0, 2.0, 2.0), self._row(20, 4.0, 4.0)]
+            result = diff_footprint_helpers.process_tfbs(
+                "TF1",
+                self._args(tmpdir),
+                {("A", "B"): (0.0, 0.5)},
+                bed_rows=rows,
+            )
+
+        self.assertEqual(float(result.at["TF1", "A_B_change"]), 0.0)
+        self.assertEqual(float(result.at["TF1", "A_B_pvalue"]), 1.0)
+
+    def test_zero_variance_unequal_means_produce_finite_statistics(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rows = [self._row(0, 2.0, 1.0)]
+            result = diff_footprint_helpers.process_tfbs(
+                "TF1",
+                self._args(tmpdir),
+                {("A", "B"): (0.0, 0.0)},
+                bed_rows=rows,
+            )
+
+        self.assertTrue(np.isfinite(float(result.at["TF1", "A_B_change"])))
+        self.assertTrue(np.isfinite(float(result.at["TF1", "A_B_pvalue"])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -79,6 +79,38 @@ class RegionListMergeTest(unittest.TestCase):
 
         self.assertEqual(self._coordinates(regions), [("chr1", 0, 10), ("chr1", 2, 8)])
 
+    def test_name_aware_merge_handles_interleaved_names(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 10, "A"]),
+                OneRegion(["chr1", 2, 8, "B"]),
+                OneRegion(["chr1", 4, 6, "A"]),
+            ]
+        )
+
+        regions.merge(name=True)
+
+        self.assertEqual(
+            [(region.chrom, region.start, region.end, region.name) for region in regions],
+            [("chr1", 0, 10, "A"), ("chr1", 2, 8, "B")],
+        )
+
+    def test_count_overlaps_uses_name_aware_geometric_unions(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 10, "A"]),
+                OneRegion(["chr1", 2, 8, "B"]),
+                OneRegion(["chr1", 4, 6, "A"]),
+            ]
+        )
+
+        overlaps = regions.count_overlaps()
+
+        self.assertEqual(overlaps["A"], 10)
+        self.assertEqual(overlaps["B"], 6)
+        self.assertEqual(overlaps[("A", "B")], 6)
+        self.assertEqual(overlaps[("B", "A")], 6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- Preserve `change = 0` and `pvalue = 1` when observed and background differential means are exactly equal, fixing #2.
- Use a finite positive scale for standardized changes so zero-variance comparisons cannot emit `NaN` or infinity.
- Merge named regions independently by chromosome and name before restoring genomic order, so interleaved labels no longer prevent same-name unions.
- Add focused regressions for exact-equal statistics, zero-variance statistics, interleaved name-aware merging, and `count_overlaps()`.
- Bump the release candidate metadata to `0.2.0rc4`.

## Root causes

The differential helper assigned the exact-equality sentinel p-value and then unconditionally overwrote it with the one-sample test result. Name-aware interval merging operated only on adjacent coordinate-sorted records, so an overlapping record with another name could separate two regions that belonged to the same union.

## Impact

The statistical edge case now has the intended null result. Name-aware overlap counting is invariant to interleaving by other labels. Ordinary `merge(name=False)` behavior, including keeping book-ended intervals separate, is unchanged. Existing pairwise peak merging uses `name=False` and is unaffected by the name-aware correction.

## Validation

- Full local suite: 367 passed, 1 skipped.
- Release-checklist `unittest` discovery completed successfully.
- All 21 console commands passed help smoke tests.
- Focused regression suite: 21 passed.
- `pip check` passed.
- Strict MkDocs build and documentation contract tests passed.
- Local `0.2.0rc4` wheel and source distribution passed `twine check`.

Closes #2.