### PR TITLE
Limit desktop releases to Windows and Apple Silicon

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -28,17 +28,8 @@ jobs:
           - os: windows-latest
             label: windows-x64
             executable: dist/fp-tools-gui.exe
-          - os: macos-15-intel
-            label: macos-intel
-            executable: dist/fp-tools-gui
           - os: macos-15
             label: macos-apple-silicon
-            executable: dist/fp-tools-gui
-          - os: ubuntu-22.04
-            label: linux-x64
-            executable: dist/fp-tools-gui
-          - os: ubuntu-24.04-arm
-            label: linux-arm64
             executable: dist/fp-tools-gui
     steps:
       - uses: actions/checkout@v7

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -84,11 +84,11 @@ python -m venv /tmp/fp-tools-pypi-smoke
 /tmp/fp-tools-pypi-smoke/bin/fp-tools-gui --help >/dev/null
 ```
 
-The `Desktop bundles` workflow must produce and smoke-test Windows x64, macOS
-Intel, macOS Apple Silicon, Linux x64, and Linux ARM64 executables. Its live
-health check verifies that the bundled Streamlit application starts, and its
-command check verifies frozen child-process dispatch. Release assets include a
-SHA-256 checksum manifest.
+The `Desktop bundles` workflow must produce and smoke-test Windows x64 and
+macOS Apple Silicon executables. Its live health check verifies that the
+bundled Streamlit application starts, and its command check verifies frozen
+child-process dispatch. Release assets include a SHA-256 checksum manifest.
+macOS Intel and Linux users install the Python package instead.
 
 The `Container` workflow builds and tests the complete environment, then
 publishes `linux/amd64` and `linux/arm64` images to

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -18,22 +18,10 @@ the GUI. Python does not need to be installed.
     Download `fp-tools-gui-macos-apple-silicon.tar.gz`, extract it, and open
     `fp-tools-gui`.
 
-=== "macOS Intel"
-
-    Download `fp-tools-gui-macos-intel.tar.gz`, extract it, and open
-    `fp-tools-gui`.
-
-=== "Linux x64 / ARM64"
-
-    Download the matching `fp-tools-gui-linux-*.tar.gz`, extract it, and run:
-
-    ```bash
-    ./fp-tools-gui
-    ```
-
 The desktop executable covers the GUI and native fp-tools analyses from BAM,
 fragment, bigWig, BED, and motif inputs. Use the complete container when a run
-also needs raw-read programs or MEME Suite.
+also needs raw-read programs or MEME Suite. Linux and macOS Intel users should
+use the Python package below.
 
 ## Complete container
 
@@ -127,11 +115,12 @@ See the [API Reference](../api.md) for complete command options.
 
 ## Platform support
 
-| Platform | Desktop / Python | Complete container |
-| --- | --- | --- |
-| Windows 10/11 x64 | Native | Docker Desktop |
-| macOS Intel/Apple Silicon | Native | Docker Desktop |
-| Linux x86_64/ARM64 | Native | Docker Engine |
+| Platform | Desktop executable | Python package | Complete container |
+| --- | --- | --- | --- |
+| Windows 10/11 x64 | Available | Available | Docker Desktop |
+| macOS Apple Silicon | Available | Available | Docker Desktop |
+| macOS Intel | — | Available | Docker Desktop |
+| Linux x86_64/ARM64 | — | Available | Docker Engine |
 
 `prepare-atac` orchestrates tools such as Bowtie 2, SAMtools, BEDTools, fastp,
 and MACS3. De novo discovery can call STREME and Tomtom. The complete container


### PR DESCRIPTION
## What changed

- Reduce the standalone GUI build matrix to Windows x64 and macOS Apple Silicon.
- Direct Linux and macOS Intel users to the Python package instead of standalone executables.
- Update the release checklist and installation platform table to match.

## What remains supported

Python wheels remain available for Windows, macOS, and Linux on Python 3.11–3.13. The container workflow is unchanged.

## Why

This cuts release time and artifact storage while retaining the two requested standalone GUI targets and full cross-platform package installation.

## Validation

- `mkdocs build --clean --strict`
- Documentation contract tests: 19 passed
- `git diff --check`