### PR TITLE
Add managed runtime and end-to-end raw-read workflow

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Smoke-test command dispatch and GUI startup
         run: python scripts/smoke_desktop_bundle.py "${{ matrix.executable }}"
       - name: Name release asset
+        if: runner.os == 'Windows'
         shell: python
         env:
           SOURCE: ${{ matrix.executable }}
@@ -58,9 +59,17 @@ jobs:
           stem = f"fp-tools-gui-{os.environ['LABEL']}"
           if os.environ["LABEL"].startswith("windows"):
               shutil.copy2(source, release / f"{stem}.exe")
-          else:
-              with tarfile.open(release / f"{stem}.tar.gz", "w:gz") as archive:
-                  archive.add(source, arcname="fp-tools-gui")
+      - name: Build unsigned Apple Silicon application image
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          app="release/fp-tools.app"
+          mkdir -p "${app}/Contents/MacOS"
+          cp dist/fp-tools-gui "${app}/Contents/MacOS/fp-tools-gui"
+          cp packaging/desktop/Info.plist "${app}/Contents/Info.plist"
+          hdiutil create -volname "fp-tools" -srcfolder "${app}" \
+            -ov -format UDZO "release/fp-tools-gui-macos-apple-silicon.dmg"
+          rm -rf "${app}"
       - uses: actions/upload-artifact@v7
         with:
           name: fp-tools-gui-${{ matrix.label }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -42,13 +42,28 @@ jobs:
           cache-environment: true
       - name: Pack and inspect runtime
         shell: bash -el {0}
+        env:
+          COMPONENT: ${{ matrix.component }}
         run: |
           mkdir -p runtime-out runtime-smoke
           conda-pack -p "${MAMBA_ROOT_PREFIX}/envs/runtime" -o "runtime-out/${{ matrix.component }}.tar.gz"
           micromamba list -n runtime --json > "runtime-out/${{ matrix.component }}-sbom.json"
           tar -xzf "runtime-out/${{ matrix.component }}.tar.gz" -C runtime-smoke
           runtime-smoke/bin/python runtime-smoke/bin/conda-unpack
-          runtime-smoke/bin/python -c "import json; json.load(open('runtime-out/${{ matrix.component }}-sbom.json'))"
+          runtime-smoke/bin/python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          json.load(open(f"runtime-out/{os.environ['COMPONENT']}-sbom.json"))
+          manifest = json.load(open("src/fp_tools/resources/runtime_manifest.json"))
+          missing = [
+              name
+              for name in manifest["components"][os.environ["COMPONENT"]]["commands"]
+              if not (Path("runtime-smoke/bin") / name).exists()
+          ]
+          assert not missing, f"Runtime is missing commands: {missing}"
+          PY
       - name: Log in to GHCR
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v4

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,0 +1,132 @@
+name: Managed runtimes
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - packaging/runtime/**
+      - src/fp_tools/runtime.py
+      - src/fp_tools/resources/runtime_manifest.json
+      - .github/workflows/runtime.yml
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  RUNTIME_REPOSITORY: ghcr.io/oncologylab/fp-tools-runtime
+
+jobs:
+  native:
+    name: ${{ matrix.target.platform }} / ${{ matrix.component }}
+    runs-on: ${{ matrix.target.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [core, meme, homer]
+        target:
+          - {runner: ubuntu-latest, platform: linux-x86_64}
+          - {runner: ubuntu-24.04-arm, platform: linux-arm64}
+          - {runner: macos-15-intel, platform: macos-x86_64}
+          - {runner: macos-15, platform: macos-arm64}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: packaging/runtime/${{ matrix.component }}.yml
+          environment-name: runtime
+          cache-environment: true
+      - name: Pack and inspect runtime
+        shell: bash -el {0}
+        run: |
+          mkdir -p runtime-out runtime-smoke
+          conda-pack -n runtime -o "runtime-out/${{ matrix.component }}.tar.gz"
+          micromamba list -n runtime --json > "runtime-out/${{ matrix.component }}-sbom.json"
+          tar -xzf "runtime-out/${{ matrix.component }}.tar.gz" -C runtime-smoke
+          runtime-smoke/bin/python runtime-smoke/bin/conda-unpack
+          runtime-smoke/bin/python -c "import json; json.load(open('runtime-out/${{ matrix.component }}-sbom.json'))"
+      - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: oras-project/setup-oras@v1
+        if: startsWith(github.ref, 'refs/tags/')
+      - name: Publish runtime artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          tag="${{ matrix.component }}-${version}-${{ matrix.target.platform }}"
+          oras push "${RUNTIME_REPOSITORY}:${tag}" \
+            "runtime-out/${{ matrix.component }}.tar.gz:application/gzip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: runtime-${{ matrix.target.platform }}-${{ matrix.component }}-metadata
+          path: runtime-out/${{ matrix.component }}-sbom.json
+
+  windows-wsl:
+    name: windows-x64 / private WSL2 runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - name: Build and export complete runtime rootfs
+        shell: bash
+        run: |
+          docker build -t fp-tools-wsl-runtime .
+          container_id="$(docker create fp-tools-wsl-runtime)"
+          trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
+          mkdir -p runtime-out
+          docker export "${container_id}" | gzip -1 > runtime-out/fp-tools-wsl-rootfs.tar.gz
+      - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: oras-project/setup-oras@v1
+        if: startsWith(github.ref, 'refs/tags/')
+      - name: Publish WSL2 runtime artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          oras push "${RUNTIME_REPOSITORY}:wsl-core-${version}-linux-x86_64" \
+            "runtime-out/fp-tools-wsl-rootfs.tar.gz:application/gzip"
+
+  publish-and-test:
+    name: public artifact and Windows WSL2 smoke test
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [native, windows-wsl]
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - name: Make the runtime repository public
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method PATCH "/orgs/oncologylab/packages/container/fp-tools-runtime" \
+            -f visibility=public
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install package and import private WSL2 distribution
+        shell: pwsh
+        run: |
+          python -m pip install --only-binary=:all: .
+          fp-tools-runtime install core
+          fp-tools-runtime status
+          $distro = (wsl.exe --list --quiet | Out-String).Replace("`0", "")
+          if ($distro -notmatch "fp-tools-0-2-0rc5") { throw "fp-tools WSL runtime was not imported" }
+          wsl.exe --distribution fp-tools-0-2-0rc5 --exec /opt/conda/bin/prepare-atac --doctor --profile modern

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash -el {0}
         run: |
           mkdir -p runtime-out runtime-smoke
-          conda-pack -n runtime -o "runtime-out/${{ matrix.component }}.tar.gz"
+          conda-pack -p "${MAMBA_ROOT_PREFIX}/envs/runtime" -o "runtime-out/${{ matrix.component }}.tar.gz"
           micromamba list -n runtime --json > "runtime-out/${{ matrix.component }}-sbom.json"
           tar -xzf "runtime-out/${{ matrix.component }}.tar.gz" -C runtime-smoke
           runtime-smoke/bin/python runtime-smoke/bin/conda-unpack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,14 @@ unless the user explicitly asks to publish the manuscript source.
   `prepare-atac`, `bulk-footprinting`, `atac-correct`, `call-footprints`,
   `match-motifs`, `diff-footprints`, `normalize-bigwig`, `plot-aggregate`,
   `review-multi-comparisons`, `run-yaml-workflow`, `fp-tools-gui`,
+  `fp-tools-runtime`,
   `discover-motifs`, `summarize-motifs`, `pseudobulk-fragments`,
   `find-signature-fp`, and `sc-footprinting`.
 - Do not reintroduce the removed TOBIAS-style console aliases. Use the current
   command names above in code, tests, docs, and examples.
+- Keep external genomics programs behind the runtime abstraction. Raw-read and
+  executable motif workflows default to the pinned managed runtime; `system`
+  and `container` remain explicit alternative backends.
 
 ## Common Development Commands
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc4
+version: 0.2.0rc5
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -1,6 +1,6 @@
 # fp-tools Development Plan
 
-Last updated: 2026-08-19
+Last updated: 2026-08-20
 
 ## Current Baseline
 
@@ -21,6 +21,11 @@ a separately planned breaking release explicitly changes the contract.
 ## Completed Capabilities
 
 - Raw-read ATAC preparation with modern and legacy processing profiles.
+- A managed, versioned external-tool runtime downloaded on first use, with
+  native Linux/macOS archives, a private WSL2 runtime for Windows, and the
+  complete container retained as an explicit backend.
+- One-command bulk analysis from FASTQ files or public run accessions through
+  portable multi-comparison HTML reports.
 - Tn5 bias correction, background scaling, footprint scoring, candidate calls,
   known-motif matching, de novo motif preparation, and aggregate plotting.
 - Replicate-aware differential footprint reports, including per-sample motif
@@ -85,10 +90,9 @@ a separately planned breaking release explicitly changes the contract.
 8. Keep region-set examples outcome-independent: define groups from external
    annotations, match baseline signal before testing, report all motifs, and
    use explicit display motifs only to configure the initial browser view.
-9. Maintain binary-wheel and desktop-bundle installation and scientific I/O
-   parity on Windows, macOS, and Linux. Keep the complete multi-architecture
-   container as the one-command route for raw FASTQ preparation and external
-   MEME programs.
+9. Maintain binary-wheel and desktop-app scientific I/O parity on Windows,
+   macOS, and Linux. Test managed-runtime artifacts and keep the complete
+   multi-architecture container as a reproducible alternative backend.
 
 ## Deferred or Experimental Work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mambaorg/micromamba:2.0.5
 
 WORKDIR /opt/fp-tools
+ENV FP_TOOLS_RUNTIME=system
 USER root
 RUN chown "$MAMBA_USER:$MAMBA_USER" /opt/fp-tools
 USER $MAMBA_USER

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Choose one route:
 
 | Route | Best for | Start |
 | --- | --- | --- |
-| Desktop executable | GUI without Python | [Download for Windows, macOS, or Linux](https://github.com/oncologylab/fp-tools/releases) |
-| Complete container | GUI plus raw-read and motif-discovery programs | `docker run --rm -p 8891:8891 ghcr.io/oncologylab/fp-tools:latest` |
-| Python package | Direct commands in an existing Python environment | `python -m pip install fp-tools-bio` |
+| Desktop app | Windows or Apple Silicon macOS | [Download](https://github.com/oncologylab/fp-tools/releases) |
+| Python package | Windows, macOS, or Linux with Python 3.11–3.13 | `python -m pip install fp-tools-bio` |
+| Container | Complete reproducible environment | `docker run --rm -p 8891:8891 ghcr.io/oncologylab/fp-tools:latest` |
 
 Python package example:
 
@@ -40,20 +40,20 @@ python -m pip install --pre fp-tools-bio
 fp-tools-gui
 ```
 
-Python 3.11–3.13 is supported on Windows, macOS, and Linux. The container is
-the complete environment for raw FASTQ processing and external MEME tools.
+External genomics programs are downloaded into a private, versioned cache on
+first use. They do not need to be installed separately. Docker remains an
+optional reproducible backend.
 
 ## Bulk ATAC-seq
 
-`bulk-footprinting` runs the complete analysis from aligned BAM and peak files.
-FASTQ preparation remains available separately through `prepare-atac`.
+`bulk-footprinting` can run from FASTQ files or public run accessions through
+the final interactive comparison report.
 
 ```bash
 bulk-footprinting \
-  --sample-table samples.tsv \
+  --reads-table reads.tsv \
   --comparison-table comparisons.tsv \
-  --genome hg38.fa.gz \
-  --blacklist hg38.blacklist.bed \
+  --genome hg38 \
   --outdir project \
   --cores 8
 ```
@@ -85,7 +85,7 @@ sc-footprinting \
 | Area | Commands |
 | --- | --- |
 | Core analysis | `prepare-atac`, `atac-correct`, `call-footprints`, `match-motifs`, `diff-footprints`, `normalize-bigwig` |
-| Workflows | `bulk-footprinting`, `sc-footprinting`, `run-yaml-workflow`, `fp-tools-gui` |
+| Workflows | `bulk-footprinting`, `sc-footprinting`, `run-yaml-workflow`, `fp-tools-gui`, `fp-tools-runtime` |
 | Reports | `plot-aggregate`, `review-multi-comparisons` |
 | De novo motifs | `discover-motifs`, `summarize-motifs` |
 | Single-cell utilities | `pseudobulk-fragments`, `find-signature-fp` |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -47,6 +47,7 @@ Primary current API checks:
 .venv/bin/review-multi-comparisons --help
 .venv/bin/run-yaml-workflow --help
 .venv/bin/fp-tools-gui --help
+.venv/bin/fp-tools-runtime --help
 .venv/bin/discover-motifs --help
 .venv/bin/summarize-motifs --help
 .venv/bin/pseudobulk-fragments --help
@@ -84,8 +85,8 @@ python -m venv /tmp/fp-tools-pypi-smoke
 /tmp/fp-tools-pypi-smoke/bin/fp-tools-gui --help >/dev/null
 ```
 
-The `Desktop bundles` workflow must produce and smoke-test Windows x64 and
-macOS Apple Silicon executables. Its live health check verifies that the
+The `Desktop bundles` workflow must produce and smoke-test a Windows x64
+executable and an unsigned Apple Silicon macOS DMG. Its live health check verifies that the
 bundled Streamlit application starts, and its command check verifies frozen
 child-process dispatch. Release assets include a SHA-256 checksum manifest.
 macOS Intel and Linux users install the Python package instead.
@@ -93,6 +94,10 @@ macOS Intel and Linux users install the Python package instead.
 The `Container` workflow builds and tests the complete environment, then
 publishes `linux/amd64` and `linux/arm64` images to
 `ghcr.io/oncologylab/fp-tools` for tagged releases.
+
+The `Managed runtimes` workflow publishes pinned core, MEME, and HOMER archives
+for Linux and macOS, plus the private Windows WSL2 root filesystem. It must
+verify archive relocation and a real Windows WSL2 import before release handoff.
 
 The manual GitHub Actions `Publish` workflow uses the repository
 `PYPI_API_TOKEN` secret. Do not paste PyPI tokens into chat, shell history, or

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,8 +9,8 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 
 | Command | Purpose |
 | --- | --- |
-| [`prepare-atac`](#prepare-atac) | Download public ATAC-seq reads or use local FASTQ files, then trim, align, filter, call peaks, calculate alignment coverage, and write QC files. Use this command when the analysis starts from reads; skip it when filtered BAM and peak files already exist. Before a large job, run `prepare-atac --doctor --profile modern` to check external programs. |
-| [`bulk-footprinting`](#bulk-footprinting) | Run the complete bulk ATAC-seq workflow from aligned BAM files, peak BED files, and an explicit comparison table. |
+| [`prepare-atac`](#prepare-atac) | Download public ATAC-seq reads or use local FASTQ files, then trim, align, filter, call peaks, calculate alignment coverage, and write QC files. Use this command when the analysis starts from reads; skip it when filtered BAM and peak files already exist. The default runtime downloads its pinned external tools on first use. |
+| [`bulk-footprinting`](#bulk-footprinting) | Run bulk ATAC-seq from raw reads or aligned inputs through interactive reports. |
 | [`atac-correct`](#atac-correct) | Estimate Tn5 sequence bias from aligned ATAC-seq fragments and subtract the expected bias contribution from the observed cut-site signal. Run this before footprint scoring. |
 | [`call-footprints`](#call-footprints) | Calculate a continuous footprint score from bias-corrected cut-site signal within accessible regions. Higher local depletion relative to flanking signal produces stronger footprint evidence. |
 | [`match-motifs`](#match-motifs) | Scan accessible regions for motif instances, measure the footprint score at each instance, and classify sample-specific bound and unbound sites. Run this when motif locations and per-sample motif summaries are needed. |
@@ -20,6 +20,7 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 | [`review-multi-comparisons`](#review-multi-comparisons) | Combine differential-footprint reports as a scalable browser bundle or one self-contained HTML report. |
 | [`run-yaml-workflow`](#run-yaml-workflow) | Run one or more fp-tools jobs from a reusable YAML configuration. |
 | [`fp-tools-gui`](#fp-tools-gui) | Launch the browser interface for configuring and running fp-tools commands. |
+| [`fp-tools-runtime`](#fp-tools-runtime) | Inspect, install, or repair the private external-tool runtime used by raw-read and de novo motif workflows. |
 | [`discover-motifs`](#discover-motifs) | Prepare or run de novo motif discovery from candidate footprint intervals or an existing FASTA file. |
 | [`summarize-motifs`](#summarize-motifs) | Summarize MEME, STREME, DREME, and Tomtom results in a compact report. |
 | [`pseudobulk-fragments`](#pseudobulk-fragments) | Group single-cell ATAC fragments by a cell-annotation column to create pseudobulk inputs. |
@@ -33,16 +34,13 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 Download public ATAC-seq reads or use local FASTQ files, then trim, align,
 filter, call peaks, calculate alignment coverage, and write QC files. Use this
 command when the analysis starts from reads; skip it when filtered BAM and peak
-files already exist. Before a large job, run
-`prepare-atac --doctor --profile modern` to check external programs.
+files already exist. The default runtime downloads its pinned external tools
+on first use.
 
 **Example command**
 
 ```bash
-prepare-atac \
-  --samples metadata.tsv \
-  --genome hg38 \
-  --outdir project
+prepare-atac --samples metadata.tsv --genome hg38 --outdir project
 ```
 
 **Primary inputs**
@@ -99,6 +97,7 @@ usage: prepare-atac [-h] [--samples SAMPLES] [--genome GENOME]
                     [--memory-gb MEMORY_GB] [--keep-intermediates]
                     [--no-resume] [--fail-fast] [--dry-run] [--doctor]
                     [--write-default-config PATH]
+                    [--runtime {auto,managed,system,container}]
 
 Download single- or paired-end ATAC-seq reads and prepare filtered BAM, peak
 BED, sequencing-depth-normalized alignment coverage bigWig, and QC files.
@@ -152,6 +151,10 @@ options:
   --doctor              Report external preprocessing dependencies and exit.
   --write-default-config PATH
                         Write the fully documented default YAML and exit.
+  --runtime {auto,managed,system,container}
+                        External-tool runtime: auto/managed provisions the
+                        pinned fp-tools runtime, system uses PATH, and
+                        container uses the complete image (default: auto).
 ```
 
 </div>
@@ -160,8 +163,7 @@ options:
 
 <div class="fp-api-card" markdown="1">
 
-Run the complete bulk ATAC-seq workflow from aligned BAM files, peak BED files,
-and an explicit comparison table.
+Run bulk ATAC-seq from raw reads or aligned inputs through interactive reports.
 
 The [bulk workflow guide](get-started/workflows/bulk-atac-seq.md) provides a runnable
 six-sample ENCODE design and the complete seven-cell-line tables.
@@ -169,41 +171,17 @@ six-sample ENCODE design and the complete seven-cell-line tables.
 **Example command**
 
 ```bash
-bulk-footprinting \
-  --sample-table samples.tsv \
-  --comparison-table comparisons.tsv \
-  --genome hg38.fa.gz \
-  --blacklist hg38.blacklist.bed \
-  --plot-aggregate all \
-  --review-format auto \
-  --outdir project \
-  --cores 8
+bulk-footprinting --reads-table reads.tsv --comparison-table comparisons.tsv --genome hg38 \
+  --outdir project --cores 8
 ```
 
 **Primary inputs**
 
-- `--sample-table` — sample, condition, BAM, and peak BED columns.
+- `--reads-table` — sample, condition, and local FASTQ or public run-accession columns.
 - `--comparison-table` — comparison, condition 1, and condition 2 columns.
-- `--genome` — reference FASTA.
-- `--blacklist` — optional blacklist BED.
+- `--genome` — `hg38`, `mm10`, or a custom genome label.
 - `--outdir` — project output directory.
 - `--cores` — total worker cores.
-- `--plot-aggregate` — `sig`, `all` (default), `top`, or `off`.
-- `--review-format` — `auto` (default), `bundle`, `standalone`, or `none`.
-
-With `--review-format auto`, aggregate-free runs produce one standalone HTML;
-other runs retain the static browser bundle.
-
-```bash
-bulk-footprinting \
-  --sample-table samples.tsv \
-  --comparison-table comparisons.tsv \
-  --genome hg38.fa.gz \
-  --plot-aggregate off \
-  --review-format auto \
-  --outdir project \
-  --cores 8
-```
 
 **Main outputs**
 
@@ -219,27 +197,34 @@ bulk-footprinting \
 | `{project}/comparisons/{comparison}/diff_footprints_{cond1}_{cond2}.html` | Portable interactive comparison report. |
 | `{project}/reports/review_multi_comparisons/index.html` | Static browser combining every requested comparison. |
 | `{project}/reports/review_multi_comparisons.html` | Aggregate-free portable review written when standalone HTML review mode is selected. |
-| `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for all five stages. |
+| `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for the workflow stages. |
 | `{project}/logs/bulk_footprinting/{stage}.stdout.log` and `{stage}.stderr.log` | Stage-specific logs for troubleshooting. |
 
-The wrapper does not run `normalize-bigwig`; `--normalization` controls only
-the differential stage. See the workflow guide for how this differs from the
-pair-specific ENCODE demo method.
-
-FASTQ preparation is a separate optional step with [`prepare-atac`](#prepare-atac).
+Use `--sample-table` instead of `--reads-table` to start from prepared BAM and
+peak files. `--runtime auto` downloads the pinned external tools only when raw
+reads require them. `--runtime system` and `--runtime container` are optional
+advanced backends.
 
 **Complete options**
 
 ```text
-usage: bulk-footprinting [-h] --sample-table SAMPLE_TABLE --comparison-table
-                         COMPARISON_TABLE --genome GENOME
-                         [--blacklist BLACKLIST] [--motifs [MOTIFS ...]]
-                         [--motif-db MOTIF_DB]
+usage: bulk-footprinting [-h]
+                         (--sample-table SAMPLE_TABLE | --reads-table READS_TABLE)
+                         --comparison-table COMPARISON_TABLE --genome GENOME
+                         [--blacklist BLACKLIST] [--config CONFIG]
+                         [--profile {modern,homer-atac}]
+                         [--reference-dir REFERENCE_DIR] [--fasta FASTA]
+                         [--bowtie2-index BOWTIE2_INDEX] [--tss TSS]
+                         [--macs-genome-size MACS_GENOME_SIZE]
+                         [--max-parallel-samples MAX_PARALLEL_SAMPLES]
+                         [--memory-gb MEMORY_GB] [--keep-intermediates]
+                         [--motifs [MOTIFS ...]] [--motif-db MOTIF_DB]
                          [--normalization {none,condition-quantile,sample-quantile}]
                          [--plot-aggregate {sig,all,top,off}]
                          [--review-format {auto,bundle,standalone,none}]
                          --outdir OUTDIR [--cores CORES] [--resume] [--force]
                          [--dry-run] [--fail-fast]
+                         [--runtime {auto,managed,system,container}]
 
 Run the complete bulk ATAC-seq footprinting workflow for explicit comparisons.
 
@@ -247,11 +232,31 @@ options:
   -h, --help            show this help message and exit
   --sample-table SAMPLE_TABLE
                         TSV with sample, condition, BAM, and peak BED columns.
+  --reads-table READS_TABLE
+                        TSV/CSV with local FASTQ paths or public run
+                        accessions; runs preparation before footprinting.
   --comparison-table COMPARISON_TABLE
                         TSV with comparison, cond1, and cond2 columns.
-  --genome GENOME       Reference genome FASTA.
+  --genome GENOME       Reference FASTA for aligned input, or hg38/mm10/custom
+                        label for raw reads.
   --blacklist BLACKLIST
                         Optional blacklist BED used during bias correction.
+  --config CONFIG       Optional prepare-atac YAML for raw reads.
+  --profile {modern,homer-atac}
+                        Raw-read processing profile (default: modern).
+  --reference-dir REFERENCE_DIR
+                        Reference cache root for raw reads.
+  --fasta FASTA         Custom reference FASTA for raw reads.
+  --bowtie2-index BOWTIE2_INDEX
+                        Existing Bowtie2 index prefix for raw reads.
+  --tss TSS             Optional TSS BED for raw-read QC.
+  --macs-genome-size MACS_GENOME_SIZE
+                        MACS3 genome size for a custom genome.
+  --max-parallel-samples MAX_PARALLEL_SAMPLES
+                        Maximum raw-read samples processed concurrently.
+  --memory-gb MEMORY_GB
+                        Total memory budget for raw-read processing.
+  --keep-intermediates  Keep raw-read intermediate files.
   --motifs [MOTIFS ...]
                         Optional motif files.
   --motif-db MOTIF_DB   Built-in motif database (default:
@@ -272,6 +277,10 @@ options:
   --dry-run             Validate inputs and print the commands without running
                         them.
   --fail-fast           Stop at the first failed stage.
+  --runtime {auto,managed,system,container}
+                        External-tool runtime: auto/managed provisions the
+                        pinned fp-tools runtime, system uses PATH, and
+                        container uses the complete image (default: auto).
 ```
 
 </div>
@@ -287,11 +296,7 @@ footprint scoring.
 **Example command**
 
 ```bash
-atac-correct \
-  --sample-table project/metadata/samples.tsv \
-  --genome hg38.fa.gz \
-  --blacklist hg38.blacklist.bed \
-  --outdir project
+atac-correct --sample-table project/metadata/samples.tsv --genome hg38.fa.gz --blacklist hg38.blacklist.bed --outdir project
 ```
 
 **Primary inputs**
@@ -464,11 +469,8 @@ produces stronger footprint evidence.
 **Example command**
 
 ```bash
-call-footprints \
-  --signals A_corrected.bw B_corrected.bw \
-  --sample-names A B \
-  --regions merged_peaks.bed \
-  --sample-output-root project/samples
+call-footprints --signals A_corrected.bw B_corrected.bw --sample-names A B \
+  --regions merged_peaks.bed --sample-output-root project/samples
 ```
 
 **Primary inputs**
@@ -624,13 +626,8 @@ when motif locations and per-sample motif summaries are needed.
 **Example command**
 
 ```bash
-match-motifs \
-  --signals A_footprints.bw B_footprints.bw \
-  --sample-names A B \
-  --genome hg38.fa.gz \
-  --peaks merged_peaks.bed \
-  --motif-db jaspar2026_vertebrates \
-  --sample-output-root project/samples
+match-motifs --signals A_footprints.bw B_footprints.bw --sample-names A B --genome hg38.fa.gz \
+  --peaks merged_peaks.bed --motif-db jaspar2026_vertebrates --sample-output-root project/samples
 ```
 
 **Primary inputs**
@@ -828,13 +825,8 @@ user-defined region sets measured in the same sample(s).
 **Example command**
 
 ```bash
-diff-footprints \
-  --sample-table project/metadata/samples.tsv \
-  --comparison-table project/metadata/comparisons.tsv \
-  --genome hg38.fa.gz \
-  --peaks project/peaks/merged_peaks_filtered.bed \
-  --motif-db jaspar2026_vertebrates \
-  --outdir project
+diff-footprints --sample-table project/metadata/samples.tsv --comparison-table project/metadata/comparisons.tsv \
+  --genome hg38.fa.gz --peaks project/peaks/merged_peaks_filtered.bed --motif-db jaspar2026_vertebrates --outdir project
 ```
 
 **Primary inputs**
@@ -1102,13 +1094,8 @@ shared signal scale before downstream scoring or plotting.
 **Example command**
 
 ```bash
-normalize-bigwig \
-  --sample-table project/metadata/samples.tsv \
-  --background project/peaks/merged_peaks_filtered.bed \
-  --outdir project \
-  --method background-scale \
-  --stat q95 \
-  --target median
+normalize-bigwig --sample-table project/metadata/samples.tsv --background project/peaks/merged_peaks_filtered.bed \
+  --outdir project --method background-scale --stat q95 --target median
 ```
 
 **Primary inputs**
@@ -1203,11 +1190,7 @@ Multiple user-defined BED files are supported through `--TFBS`. Multiple
 **Example command**
 
 ```bash
-plot-aggregate \
-  --sample-table project/metadata/samples.tsv \
-  --motifs SPIB CEBPB \
-  --site-set bound \
-  --outdir project
+plot-aggregate --sample-table project/metadata/samples.tsv --motifs SPIB CEBPB --site-set bound --outdir project
 ```
 
 **Primary inputs**
@@ -1394,13 +1377,10 @@ self-contained HTML report.
 **Example command**
 
 ```bash
-review-multi-comparisons \
-  --inputs project/comparisons \
-  --output-dir project/reports/review_multi_comparisons \
+review-multi-comparisons --inputs project/comparisons --output-dir project/reports/review_multi_comparisons \
   --default-comparison "HNF4A + FOXA2" "No HNF4A/FOXA2" \
   --default-aggregate-motifs MA1494.2 MA0484.3 MA0047.4 MA0148.5 MA0046.3 MA0153.2 MA0102.5 MA0466.4 \
-  --default-aggregate-plots 8 \
-  --documentation-url https://oncologylab.github.io/fp-tools/
+  --default-aggregate-plots 8 --documentation-url https://oncologylab.github.io/fp-tools/
 ```
 
 **Primary inputs**
@@ -1438,10 +1418,8 @@ volcano, ranked-motif, logo, and SVG-export views. Aggregate controls appear
 only when profiles exist.
 
 ```bash
-review-multi-comparisons \
-  --inputs baseline/report.html dose1/report.html dose2/report.html \
-  --labels Baseline "Dose 1" "Dose 2" \
-  --output-html review.html
+review-multi-comparisons --inputs baseline/report.html dose1/report.html dose2/report.html \
+  --labels Baseline "Dose 1" "Dose 2" --output-html review.html
 ```
 
 **Complete options**
@@ -1519,8 +1497,7 @@ Run one or more fp-tools jobs from a reusable YAML configuration.
 **Example command**
 
 ```bash
-run-yaml-workflow \
-  --config examples/gui_configs/diff_footprints_single.yml
+run-yaml-workflow --config examples/gui_configs/diff_footprints_single.yml
 ```
 
 **Primary inputs**
@@ -1565,14 +1542,14 @@ options:
 
 Launch the browser interface for configuring and running fp-tools commands.
 
+The GUI is available through the Python package, the complete container, and
+the self-contained desktop downloads on the
+[release page](https://github.com/oncologylab/fp-tools/releases).
+
 **Example command**
 
 ```bash
-fp-tools-gui \
-  --host 127.0.0.1 \
-  --port 8891 \
-  --run-dir project/gui_runs \
-  --no-browser
+fp-tools-gui --host 127.0.0.1 --port 8891 --run-dir project/gui_runs --no-browser
 ```
 
 **Primary inputs**
@@ -1594,8 +1571,8 @@ Files under `{run_dir}` are local run state. A saved YAML remains runnable with
 
 ## Local computer
 
-Run `fp-tools-gui`. A browser opens after the server is ready. If it does not,
-open the local URL printed in the terminal.
+Open the desktop executable or run `fp-tools-gui`. A browser opens after the
+server is ready. If it does not, open the local URL printed in the terminal.
 
 ## Remote Linux server
 
@@ -1633,6 +1610,49 @@ options:
 
 </div>
 
+## `fp-tools-runtime`
+
+<div class="fp-api-card" markdown="1">
+
+Inspect, install, or repair the private external-tool runtime used by raw-read
+and de novo motif workflows.
+
+**Example command**
+
+```bash
+fp-tools-runtime status
+```
+
+**Primary inputs**
+
+The `status` action takes no input files.
+
+**Main outputs**
+
+The command reports each runtime component, platform, installation state, and
+cache location. `install core` prepares raw-read tools; MEME Suite and HOMER
+components are installed only when requested by their workflows.
+
+**Complete options**
+
+```text
+usage: fp-tools-runtime [-h] {status,install,repair} ...
+
+Inspect, install, or repair the managed fp-tools runtime.
+
+positional arguments:
+  {status,install,repair}
+    status              Report managed runtime availability and installation
+                        state.
+    install             Install a runtime component.
+    repair              Repair a runtime component.
+
+options:
+  -h, --help            show this help message and exit
+```
+
+</div>
+
 ## `discover-motifs`
 
 <div class="fp-api-card" markdown="1">
@@ -1643,13 +1663,8 @@ an existing FASTA file.
 **Example command**
 
 ```bash
-discover-motifs \
-  --candidates project/samples/sample/footprints/sample_candidate_footprints.bed \
-  --genome hg38.fa.gz \
-  --flank 75 \
-  --method streme \
-  --known-motif-db jaspar2026_vertebrates \
-  --outdir project/de_novo/sample
+discover-motifs --candidates project/samples/sample/footprints/sample_candidate_footprints.bed --genome hg38.fa.gz \
+  --flank 75 --method streme --known-motif-db jaspar2026_vertebrates --outdir project/de_novo/sample --execute
 ```
 
 **Primary inputs**
@@ -1660,6 +1675,7 @@ discover-motifs \
 - `--method` — discovery method; the example uses STREME.
 - `--known-motif-db` — optional known-motif database for Tomtom matching.
 - `--outdir` — directory for candidate FASTA files and discovery results.
+- `--execute` — run discovery immediately using the managed MEME Suite runtime.
 
 **Main outputs**
 
@@ -1682,6 +1698,7 @@ usage: discover-motifs [-h] (--fasta FASTA | --candidates CANDIDATES)
                        [--known-motifs KNOWN_MOTIFS]
                        [--known-motif-db KNOWN_MOTIF_DB] [--list-motif-dbs]
                        [--extra-args ...] [--execute]
+                       [--runtime {auto,managed,system,container}]
 
 Prepare or run a de novo motif discovery command plan.
 
@@ -1706,6 +1723,10 @@ options:
   --list-motif-dbs      List available built-in motif databases and exit.
   --extra-args ...      Additional arguments appended to MEME/DREME/STREME.
   --execute             Run the generated script immediately.
+  --runtime {auto,managed,system,container}
+                        External-tool runtime: auto/managed provisions the
+                        pinned fp-tools runtime, system uses PATH, and
+                        container uses the complete image (default: auto).
 ```
 
 </div>
@@ -1719,10 +1740,8 @@ Summarize MEME, STREME, DREME, and Tomtom results in a compact report.
 **Example command**
 
 ```bash
-summarize-motifs \
-  --meme-txt project/de_novo/sample/streme/streme.txt \
-  --tomtom-tsv project/de_novo/sample/tomtom/tomtom.tsv \
-  --out-tsv project/de_novo/sample/motif_summary.tsv
+summarize-motifs --meme-txt project/de_novo/sample/streme/streme.txt \
+  --tomtom-tsv project/de_novo/sample/tomtom/tomtom.tsv --out-tsv project/de_novo/sample/motif_summary.tsv
 ```
 
 **Primary inputs**
@@ -1770,13 +1789,8 @@ pseudobulk inputs.
 **Example command**
 
 ```bash
-pseudobulk-fragments \
-  --fragments pbmc_fragments.tsv.gz \
-  --annotations cell_annotations.tsv \
-  --group-by cell_type \
-  --genome-sizes hg38.chrom.sizes \
-  --write-cutsite-bigwigs \
-  --outdir project/pseudobulk/fragments
+pseudobulk-fragments --fragments pbmc_fragments.tsv.gz --annotations cell_annotations.tsv --group-by cell_type \
+  --genome-sizes hg38.chrom.sizes --write-cutsite-bigwigs --outdir project/pseudobulk/fragments
 ```
 
 **Primary inputs**
@@ -1876,12 +1890,8 @@ motif analyses.
 **Example command**
 
 ```bash
-find-signature-fp \
-  --annotations cell_annotations.tsv \
-  --fragments pbmc_fragments.tsv.gz \
-  --h5ad pbmc_embedding.h5ad \
-  --tf-site-dir marker_motif_sites \
-  --all-motif-results project/pseudobulk/pseudobulk_diff_footprints_results.txt \
+find-signature-fp --annotations cell_annotations.tsv --fragments pbmc_fragments.tsv.gz --h5ad pbmc_embedding.h5ad \
+  --tf-site-dir marker_motif_sites --all-motif-results project/pseudobulk/pseudobulk_diff_footprints_results.txt \
   --outdir project/pseudobulk/signature_fp
 ```
 
@@ -2036,16 +2046,9 @@ signature reporting for single-cell ATAC-seq data.
 **Example command**
 
 ```bash
-sc-footprinting \
-  --fragments pbmc_fragments.tsv.gz \
-  --annotations cell_annotations.tsv \
-  --h5ad cell_embedding.h5ad \
-  --group-by cell_type \
-  --genome-sizes hg38.chrom.sizes \
-  --genome hg38.fa.gz \
-  --peaks merged_peaks.bed \
-  --motif-db jaspar2026_vertebrates \
-  --outdir project/pseudobulk
+sc-footprinting --fragments pbmc_fragments.tsv.gz --annotations cell_annotations.tsv --h5ad cell_embedding.h5ad \
+  --group-by cell_type --genome-sizes hg38.chrom.sizes --genome hg38.fa.gz --peaks merged_peaks.bed \
+  --motif-db jaspar2026_vertebrates --outdir project/pseudobulk
 ```
 
 **Primary inputs**

--- a/docs/get-started/commands/bulk-footprinting.md
+++ b/docs/get-started/commands/bulk-footprinting.md
@@ -1,7 +1,6 @@
 # [`bulk-footprinting`](../../api.md#bulk-footprinting)
 
-Run the complete bulk ATAC-seq workflow from aligned BAM files, peak BED files,
-and an explicit comparison table.
+Run bulk ATAC-seq from raw reads or aligned inputs through interactive reports.
 
 The [bulk workflow guide](../workflows/bulk-atac-seq.md) provides a runnable
 six-sample ENCODE design and the complete seven-cell-line tables.
@@ -9,34 +8,17 @@ six-sample ENCODE design and the complete seven-cell-line tables.
 ## Example command
 
 ```bash
-bulk-footprinting --sample-table samples.tsv --comparison-table comparisons.tsv --genome hg38.fa.gz \
-  --blacklist hg38.blacklist.bed --plot-aggregate all --review-format auto --outdir project --cores 8
+bulk-footprinting --reads-table reads.tsv --comparison-table comparisons.tsv --genome hg38 \
+  --outdir project --cores 8
 ```
 
 ## Primary inputs
 
-- `--sample-table` — sample, condition, BAM, and peak BED columns.
+- `--reads-table` — sample, condition, and local FASTQ or public run-accession columns.
 - `--comparison-table` — comparison, condition 1, and condition 2 columns.
-- `--genome` — reference FASTA.
-- `--blacklist` — optional blacklist BED.
+- `--genome` — `hg38`, `mm10`, or a custom genome label.
 - `--outdir` — project output directory.
 - `--cores` — total worker cores.
-- `--plot-aggregate` — `sig`, `all` (default), `top`, or `off`.
-- `--review-format` — `auto` (default), `bundle`, `standalone`, or `none`.
-
-With `--review-format auto`, aggregate-free runs produce one standalone HTML;
-other runs retain the static browser bundle.
-
-```bash
-bulk-footprinting \
-  --sample-table samples.tsv \
-  --comparison-table comparisons.tsv \
-  --genome hg38.fa.gz \
-  --plot-aggregate off \
-  --review-format auto \
-  --outdir project \
-  --cores 8
-```
 
 ## Main outputs
 
@@ -52,11 +34,10 @@ bulk-footprinting \
 | `{project}/comparisons/{comparison}/diff_footprints_{cond1}_{cond2}.html` | Portable interactive comparison report. |
 | `{project}/reports/review_multi_comparisons/index.html` | Static browser combining every requested comparison. |
 | `{project}/reports/review_multi_comparisons.html` | Aggregate-free portable review written when standalone HTML review mode is selected. |
-| `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for all five stages. |
+| `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for the workflow stages. |
 | `{project}/logs/bulk_footprinting/{stage}.stdout.log` and `{stage}.stderr.log` | Stage-specific logs for troubleshooting. |
 
-The wrapper does not run `normalize-bigwig`; `--normalization` controls only
-the differential stage. See the workflow guide for how this differs from the
-pair-specific ENCODE demo method.
-
-FASTQ preparation is a separate optional step with [`prepare-atac`](prepare-atac.md).
+Use `--sample-table` instead of `--reads-table` to start from prepared BAM and
+peak files. `--runtime auto` downloads the pinned external tools only when raw
+reads require them. `--runtime system` and `--runtime container` are optional
+advanced backends.

--- a/docs/get-started/commands/discover-motifs.md
+++ b/docs/get-started/commands/discover-motifs.md
@@ -7,7 +7,7 @@ an existing FASTA file.
 
 ```bash
 discover-motifs --candidates project/samples/sample/footprints/sample_candidate_footprints.bed --genome hg38.fa.gz \
-  --flank 75 --method streme --known-motif-db jaspar2026_vertebrates --outdir project/de_novo/sample
+  --flank 75 --method streme --known-motif-db jaspar2026_vertebrates --outdir project/de_novo/sample --execute
 ```
 
 ## Primary inputs
@@ -18,6 +18,7 @@ discover-motifs --candidates project/samples/sample/footprints/sample_candidate_
 - `--method` — discovery method; the example uses STREME.
 - `--known-motif-db` — optional known-motif database for Tomtom matching.
 - `--outdir` — directory for candidate FASTA files and discovery results.
+- `--execute` — run discovery immediately using the managed MEME Suite runtime.
 
 ## Main outputs
 

--- a/docs/get-started/commands/fp-tools-runtime.md
+++ b/docs/get-started/commands/fp-tools-runtime.md
@@ -1,0 +1,20 @@
+# [`fp-tools-runtime`](../../api.md#fp-tools-runtime)
+
+Inspect, install, or repair the private external-tool runtime used by raw-read
+and de novo motif workflows.
+
+## Example command
+
+```bash
+fp-tools-runtime status
+```
+
+## Primary inputs
+
+The `status` action takes no input files.
+
+## Main outputs
+
+The command reports each runtime component, platform, installation state, and
+cache location. `install core` prepares raw-read tools; MEME Suite and HOMER
+components are installed only when requested by their workflows.

--- a/docs/get-started/commands/prepare-atac.md
+++ b/docs/get-started/commands/prepare-atac.md
@@ -10,8 +10,8 @@ core_nav:
 Download public ATAC-seq reads or use local FASTQ files, then trim, align,
 filter, call peaks, calculate alignment coverage, and write QC files. Use this
 command when the analysis starts from reads; skip it when filtered BAM and peak
-files already exist. Before a large job, run
-`prepare-atac --doctor --profile modern` to check external programs.
+files already exist. The default runtime downloads its pinned external tools
+on first use.
 
 ## Example command
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -11,17 +11,17 @@ the GUI. Python does not need to be installed.
 
     Download `fp-tools-gui-windows-x64.exe` from the
     [release page](https://github.com/oncologylab/fp-tools/releases),
-    then open it.
+    then open it. This preview is unsigned, so Windows may ask you to confirm.
 
 === "macOS Apple Silicon"
 
-    Download `fp-tools-gui-macos-apple-silicon.tar.gz`, extract it, and open
-    `fp-tools-gui`.
+    Download `fp-tools-gui-macos-apple-silicon.dmg`, open it, and launch
+    `fp-tools`. This preview is unsigned; on first launch, Control-click the app
+    and choose **Open**.
 
-The desktop executable covers the GUI and native fp-tools analyses from BAM,
-fragment, bigWig, BED, and motif inputs. Use the complete container when a run
-also needs raw-read programs or MEME Suite. Linux and macOS Intel users should
-use the Python package below.
+The app downloads its pinned analysis runtime on the first FASTQ or motif-
+discovery run. Windows uses a private WSL2 distribution; fp-tools enables it
+with permission if needed, and Windows may request one restart.
 
 ## Complete container
 
@@ -75,20 +75,19 @@ atac-correct --help
 diff-footprints --help
 ```
 
-## External analysis programs
+## Managed analysis runtime
 
-Raw-read preparation uses external genomics programs. The default `modern`
-profile requires Fastp, Bowtie2 (including `bowtie2-build`), Samtools, Bedtools,
-and MACS3. Check the active environment before downloading data:
+Raw-read and motif-discovery commands automatically install their pinned tools
+in the fp-tools cache. Inspect or prepare that cache with:
 
 ```bash
-prepare-atac --doctor --profile modern
+fp-tools-runtime status
+fp-tools-runtime install core
 ```
 
-The alternative `homer-atac` profile uses Trim Galore, Bowtie2, Picard,
-Samtools, Bedtools, and HOMER. The doctor report identifies every missing
-program. Commands that start from existing bigWigs do not require the complete
-raw-read toolchain.
+Use `--runtime system` to use programs already on `PATH`, or `--runtime
+container` to run the complete public image. Workflows starting from BAM,
+bigWig, BED, or fragment inputs do not download the raw-read runtime.
 
 ## GUI
 

--- a/docs/get-started/tool-overview.md
+++ b/docs/get-started/tool-overview.md
@@ -23,10 +23,11 @@ comparison table, ENCODE downloads, and the expected output layout.
 
 ## Workflow and interface
 
-- [`bulk-footprinting`](commands/bulk-footprinting.md) — run the complete bulk workflow from aligned BAM and peak files.
+- [`bulk-footprinting`](commands/bulk-footprinting.md) — run the complete bulk workflow from raw reads or aligned inputs.
 - [`sc-footprinting`](commands/sc-footprinting.md) — run pseudobulk and per-cell single-cell ATAC-seq footprinting.
 - [`run-yaml-workflow`](commands/run-yaml-workflow.md) — run command-compatible jobs from YAML.
 - [`fp-tools-gui`](commands/fp-tools-gui.md) — launch the browser interface.
+- [`fp-tools-runtime`](commands/fp-tools-runtime.md) — inspect or prepare the managed external-tool runtime.
 
 ## De Novo Motif Discovery
 

--- a/docs/get-started/workflows/bulk-atac-seq.md
+++ b/docs/get-started/workflows/bulk-atac-seq.md
@@ -8,10 +8,11 @@ and [ENCSR868FGK](https://www.encodeproject.org/experiments/ENCSR868FGK/).
 
 ## Before you start
 
-Install fp-tools and verify the external programs used by raw-read processing:
+Install fp-tools. The pinned raw-read programs are prepared automatically on
+first use; their status is available without downloading data:
 
 ```bash
-prepare-atac --doctor --profile modern
+fp-tools-runtime status
 ```
 
 For a custom genome, provide a matching FASTA, Bowtie2 index, chromosome names,
@@ -20,8 +21,8 @@ assembly. The examples below use hg38.
 
 ## Starting from FASTQ files
 
-[`prepare-atac`](../commands/prepare-atac.md) accepts a tab-separated or
-comma-separated sample sheet.
+`bulk-footprinting --reads-table` accepts a tab-separated or comma-separated
+sample sheet and runs preparation plus all downstream stages.
 
 For paired-end data:
 
@@ -45,12 +46,12 @@ Use the columns shown for your library layout. The ENCODE download includes
 optional provenance columns that may be left out.
 
 ```bash
-prepare-atac --samples encode_hepg2_k562_fastq_urls.tsv --genome hg38 --outdir project --cores 8
+bulk-footprinting --reads-table encode_hepg2_k562_fastq_urls.tsv \
+  --comparison-table encode_hepg2_k562_comparisons.tsv --genome hg38 \
+  --outdir project --cores 8
 ```
 
-The downstream aligned-data table is written to
-`project/metadata/samples.tsv`; use that generated table for the remaining
-commands.
+The generated aligned-data table is retained at `project/metadata/samples.tsv`.
 
 ## Starting from aligned ENCODE data
 

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc4
+#      python -m pip install fp-tools-bio==0.2.0rc5
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc4}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc5}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
               - sc-footprinting: get-started/commands/sc-footprinting.md
               - run-yaml-workflow: get-started/commands/run-yaml-workflow.md
               - fp-tools-gui: get-started/commands/fp-tools-gui.md
+              - fp-tools-runtime: get-started/commands/fp-tools-runtime.md
           - De Novo Motif Discovery:
               - discover-motifs: get-started/commands/discover-motifs.md
               - summarize-motifs: get-started/commands/summarize-motifs.md

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key><string>fp-tools</string>
+  <key>CFBundleExecutable</key><string>fp-tools-gui</string>
+  <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
+  <key>CFBundleName</key><string>fp-tools</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc5</string>
+  <key>LSMinimumSystemVersion</key><string>12.0</string>
+  <key>NSHighResolutionCapable</key><true/>
+</dict>
+</plist>

--- a/packaging/runtime/core.yml
+++ b/packaging/runtime/core.yml
@@ -1,0 +1,18 @@
+name: fp-tools-runtime-core
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.12
+  - conda-pack>=0.8
+  - fastp>=1.0
+  - fastqc>=0.12
+  - bowtie2>=2.5
+  - samtools>=1.23
+  - bedtools>=2.31
+  - macs3>=3.0
+  - multiqc>=1.25
+  - sra-tools>=3.1
+  - pigz>=2.8
+  - curl
+  - ucsc-bedgraphtobigwig

--- a/packaging/runtime/homer.yml
+++ b/packaging/runtime/homer.yml
@@ -1,0 +1,10 @@
+name: fp-tools-runtime-homer
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.12
+  - conda-pack>=0.8
+  - trim-galore>=0.6
+  - picard>=2.26
+  - homer>=4.11

--- a/packaging/runtime/meme.yml
+++ b/packaging/runtime/meme.yml
@@ -1,0 +1,8 @@
+name: fp-tools-runtime-meme
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.12
+  - conda-pack>=0.8
+  - meme>=5.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc4"
+version = "0.2.0rc5"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -85,6 +85,7 @@ bulk-footprinting = "fp_tools.tools.bulk_footprinting:main"
 run-yaml-workflow = "fp_tools.cli_batch:main"
 run-workflow = "fp_tools.cli_compat:run_workflow_main"
 fp-tools-gui = "fp_tools.cli_gui:main"
+fp-tools-runtime = "fp_tools.cli_runtime:main"
 discover-motifs = "fp_tools.tools.motif_discovery:motif_discovery_plan_main"
 summarize-motifs = "fp_tools.tools.motif_discovery:motif_report_main"
 motif-discovery = "fp_tools.cli_compat:motif_discovery_main"
@@ -99,6 +100,7 @@ public-console-scripts = [
   "prepare-atac", "bulk-footprinting", "atac-correct", "call-footprints",
   "match-motifs", "diff-footprints", "normalize-bigwig", "plot-aggregate",
   "review-multi-comparisons", "run-yaml-workflow", "fp-tools-gui",
+  "fp-tools-runtime",
   "discover-motifs", "summarize-motifs", "pseudobulk-fragments",
   "find-signature-fp", "sc-footprinting"
 ]
@@ -119,6 +121,7 @@ include = ["fp_tools*"]
 [tool.setuptools.package-data]
 "fp_tools.utils" = ["*.pyx", "*.pxd"]
 "fp_tools.resources.motifs" = ["*.txt"]
+"fp_tools.resources" = ["*.json"]
 "fp_tools.resources.static_browser" = ["*.html", "*.js", "*.css"]
 
 [tool.pytest.ini_options]
@@ -143,7 +146,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc4"
+version = "0.2.0rc5"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"
@@ -196,6 +199,7 @@ bulk-footprinting = "fp_tools.tools.bulk_footprinting:main"
 run-yaml-workflow = "fp_tools.cli_batch:main"
 run-workflow = "fp_tools.cli_compat:run_workflow_main"
 fp-tools-gui = "fp_tools.cli_gui:main"
+fp-tools-runtime = "fp_tools.cli_runtime:main"
 discover-motifs = "fp_tools.tools.motif_discovery:motif_discovery_plan_main"
 summarize-motifs = "fp_tools.tools.motif_discovery:motif_report_main"
 motif-discovery = "fp_tools.cli_compat:motif_discovery_main"

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc4"
+__version__ = "0.2.0rc5"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/cli_runtime.py
+++ b/src/fp_tools/cli_runtime.py
@@ -1,0 +1,65 @@
+"""Inspect, install, or repair the managed fp-tools runtime."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import shutil
+
+from fp_tools.runtime import (
+    RuntimeProvisionError,
+    ensure_native_runtime,
+    load_runtime_manifest,
+    platform_key,
+    runtime_cache_root,
+    runtime_status,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="fp-tools-runtime", description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+    subparsers.add_parser("status", help="Report managed runtime availability and installation state.")
+    for action in ("install", "repair"):
+        child = subparsers.add_parser(action, help=f"{action.title()} a runtime component.")
+        child.add_argument(
+            "component",
+            choices=tuple(load_runtime_manifest()["components"]),
+            nargs="?",
+            default="core",
+        )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.action == "status":
+        print("component\tplatform\tavailable\tinstalled\tlocation")
+        for row in runtime_status():
+            print("\t".join(row[key] for key in ("component", "platform", "available", "installed", "location")))
+        return 0
+    if args.action == "repair" and not platform_key().startswith("windows-"):
+        target = runtime_cache_root() / load_runtime_manifest()["runtime_version"] / platform_key() / args.component
+        if target.exists():
+            shutil.rmtree(target)
+    elif args.action == "repair":
+        manifest = load_runtime_manifest()
+        safe_version = "".join(
+            char if char.isalnum() else "-" for char in manifest["runtime_version"]
+        ).strip("-")
+        if shutil.which("wsl.exe"):
+            subprocess.run(
+                ["wsl.exe", "--unregister", f"fp-tools-{safe_version}"],
+                check=False,
+            )
+    try:
+        activation = ensure_native_runtime(args.component)
+    except RuntimeProvisionError as exc:
+        raise SystemExit(f"fp-tools-runtime: error: {exc}") from exc
+    location = activation.distro or str(activation.prefix)
+    print(f"{args.component} runtime ready: {location}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/fp_tools/command_registry.py
+++ b/src/fp_tools/command_registry.py
@@ -24,6 +24,7 @@ COMMAND_TARGETS: dict[str, str] = {
     "review-multi-comparisons": "fp_tools.tools.review_multi_comparisons:main",
     "run-yaml-workflow": "fp_tools.cli_batch:main",
     "fp-tools-gui": "fp_tools.cli_gui:main",
+    "fp-tools-runtime": "fp_tools.cli_runtime:main",
     "discover-motifs": "fp_tools.tools.motif_discovery:motif_discovery_plan_main",
     "summarize-motifs": "fp_tools.tools.motif_discovery:motif_report_main",
     "pseudobulk-fragments": "fp_tools.tools.pseudobulk:main",

--- a/src/fp_tools/gui_app.py
+++ b/src/fp_tools/gui_app.py
@@ -63,14 +63,16 @@ NAV_GROUPS = [
 GENERIC_TOOL_DEFAULTS: dict[str, dict[str, Any]] = {
     "bulk-footprinting": {
         "sample_id": "bulk_footprinting_run",
-        "sample_table": "samples.tsv",
+        "reads_table": "reads.tsv",
+        "sample_table": "",
         "comparison_table": "comparisons.tsv",
-        "genome": "genome.fa",
+        "genome": "hg38",
         "outdir": "results/bulk_footprinting",
         "motif_db": "jaspar2026_vertebrates",
         "plot_aggregate": "all",
         "review_format": "auto",
         "cores": 4,
+        "runtime": "auto",
     },
     "review-multi-comparisons": {
         "sample_id": "comparison_browser_run",

--- a/src/fp_tools/gui_config.py
+++ b/src/fp_tools/gui_config.py
@@ -82,7 +82,7 @@ REQUIRED_FIELDS = {
     "normalize-bigwig": ("bigwigs", "background", "outdir"),
     "plot-aggregate": ("output",),
     "review-multi-comparisons": ("inputs",),
-    "bulk-footprinting": ("sample_table", "comparison_table", "genome", "outdir"),
+    "bulk-footprinting": ("comparison_table", "genome", "outdir"),
     "discover-motifs": ("outdir",),
     "summarize-motifs": ("out_tsv",),
     "pseudobulk-fragments": ("fragments", "annotations", "group_by", "outdir"),
@@ -353,6 +353,13 @@ def validate_config(config: Mapping[str, Any]) -> list[str]:
             if tool == "discover-motifs":
                 if not str(item.get("fasta") or "").strip() and not str(item.get("candidates") or "").strip():
                     errors.append(f"{job_name}: provide either 'fasta' or 'candidates'")
+            if tool == "bulk-footprinting":
+                reads_table = str(item.get("reads_table") or "").strip()
+                sample_table = str(item.get("sample_table") or "").strip()
+                if bool(reads_table) == bool(sample_table):
+                    errors.append(
+                        f"{job_name}: provide exactly one of 'reads_table' or 'sample_table'"
+                    )
             if tool == "diff-footprints":
                 comparison_axis = str(item.get("comparison_axis") or item.get("comparison-axis") or "conditions")
                 signals = item.get("signals") or []

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,0 +1,65 @@
+{
+  "schema": 1,
+  "runtime_version": "0.2.0rc5",
+  "repository": "ghcr.io/oncologylab/fp-tools-runtime",
+  "components": {
+    "core": {
+      "commands": [
+        "fastp",
+        "fastqc",
+        "bowtie2",
+        "bowtie2-build",
+        "samtools",
+        "bedtools",
+        "macs3",
+        "multiqc",
+        "prefetch",
+        "vdb-validate",
+        "fasterq-dump",
+        "pigz",
+        "curl",
+        "bedGraphToBigWig"
+      ]
+    },
+    "meme": {
+      "commands": ["meme", "dreme", "streme", "tomtom"]
+    },
+    "homer": {
+      "commands": [
+        "trim_galore",
+        "picard",
+        "makeTagDirectory",
+        "makeUCSCfile",
+        "findPeaks",
+        "pos2bed.pl"
+      ]
+    }
+  },
+  "artifacts": {
+    "linux-x86_64": {
+      "core": {"tag": "core-0.2.0rc5-linux-x86_64"},
+      "meme": {"tag": "meme-0.2.0rc5-linux-x86_64"},
+      "homer": {"tag": "homer-0.2.0rc5-linux-x86_64"}
+    },
+    "linux-arm64": {
+      "core": {"tag": "core-0.2.0rc5-linux-arm64"},
+      "meme": {"tag": "meme-0.2.0rc5-linux-arm64"},
+      "homer": {"tag": "homer-0.2.0rc5-linux-arm64"}
+    },
+    "macos-x86_64": {
+      "core": {"tag": "core-0.2.0rc5-macos-x86_64"},
+      "meme": {"tag": "meme-0.2.0rc5-macos-x86_64"},
+      "homer": {"tag": "homer-0.2.0rc5-macos-x86_64"}
+    },
+    "macos-arm64": {
+      "core": {"tag": "core-0.2.0rc5-macos-arm64"},
+      "meme": {"tag": "meme-0.2.0rc5-macos-arm64"},
+      "homer": {"tag": "homer-0.2.0rc5-macos-arm64"}
+    },
+    "windows-x86_64": {
+      "core": {"tag": "wsl-core-0.2.0rc5-linux-x86_64"},
+      "meme": {"tag": "wsl-core-0.2.0rc5-linux-x86_64"},
+      "homer": {"tag": "wsl-core-0.2.0rc5-linux-x86_64"}
+    }
+  }
+}

--- a/src/fp_tools/runtime.py
+++ b/src/fp_tools/runtime.py
@@ -1,0 +1,587 @@
+"""Provision and select pinned external-tool runtimes for fp-tools.
+
+Normal Python and desktop installations use the managed runtime automatically
+when a workflow needs command-line genomics programs.  System programs and the
+complete container remain explicit advanced backends.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from fp_tools import __version__
+
+
+RUNTIME_MODES = ("auto", "managed", "system", "container")
+OCI_ACCEPT = (
+    "application/vnd.oci.image.manifest.v1+json,"
+    "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+
+class RuntimeProvisionError(RuntimeError):
+    """Raised when the managed external-tool runtime cannot be prepared."""
+
+
+@dataclass(frozen=True)
+class RuntimeActivation:
+    mode: str
+    component: str
+    prefix: Path | None = None
+    distro: str | None = None
+
+
+def add_runtime_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--runtime",
+        choices=RUNTIME_MODES,
+        default=os.environ.get("FP_TOOLS_RUNTIME", "auto"),
+        help=(
+            "External-tool runtime: auto/managed provisions the pinned fp-tools "
+            "runtime, system uses PATH, and container uses the complete image "
+            "(default: auto)."
+        ),
+    )
+
+
+def platform_key() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    arch = {
+        "amd64": "x86_64",
+        "x64": "x86_64",
+        "x86_64": "x86_64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(machine, machine)
+    if system == "darwin":
+        return f"macos-{arch}"
+    if system == "windows":
+        return f"windows-{arch}"
+    if system == "linux":
+        return f"linux-{arch}"
+    raise RuntimeProvisionError(f"Unsupported runtime platform: {system}-{machine}")
+
+
+def runtime_cache_root() -> Path:
+    override = os.environ.get("FP_TOOLS_RUNTIME_CACHE")
+    if override:
+        return Path(override).expanduser().resolve()
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / "fp-tools" / "runtimes"
+    if platform.system() == "Darwin":
+        return Path.home() / "Library" / "Caches" / "fp-tools" / "runtimes"
+    base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return base / "fp-tools" / "runtimes"
+
+
+def load_runtime_manifest() -> dict:
+    manifest = resources.files("fp_tools.resources").joinpath("runtime_manifest.json")
+    return json.loads(manifest.read_text(encoding="utf-8"))
+
+
+def _runtime_mode(value: str | None) -> str:
+    mode = str(value or os.environ.get("FP_TOOLS_RUNTIME", "auto")).lower()
+    if mode not in RUNTIME_MODES:
+        raise RuntimeProvisionError(
+            f"Unknown runtime mode {mode!r}; choose {', '.join(RUNTIME_MODES)}"
+        )
+    return "managed" if mode == "auto" else mode
+
+
+def _runtime_spec(component: str, target_platform: str | None = None) -> dict:
+    manifest = load_runtime_manifest()
+    target = target_platform or platform_key()
+    try:
+        artifact = manifest["artifacts"][target][component]
+    except KeyError as exc:
+        raise RuntimeProvisionError(
+            f"Managed runtime component {component!r} is not available for {target}."
+        ) from exc
+    return {
+        "schema": manifest["schema"],
+        "runtime_version": manifest["runtime_version"],
+        "repository": manifest["repository"],
+        "commands": manifest["components"][component]["commands"],
+        **artifact,
+    }
+
+
+def _request_json(url: str, headers: dict[str, str] | None = None) -> tuple[dict, dict]:
+    request = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.load(response), dict(response.headers)
+
+
+def _oci_bearer_token(repository: str) -> str:
+    registry, image = repository.split("/", 1)
+    query = urllib.parse.urlencode(
+        {"service": registry, "scope": f"repository:{image}:pull"}
+    )
+    payload, _ = _request_json(f"https://{registry}/token?{query}")
+    token = payload.get("token") or payload.get("access_token")
+    if not token:
+        raise RuntimeProvisionError(f"No anonymous pull token returned for {repository}")
+    return str(token)
+
+
+def _resolve_oci_layer(repository: str, tag: str) -> tuple[str, int, str]:
+    registry, image = repository.split("/", 1)
+    token = _oci_bearer_token(repository)
+    headers = {"Authorization": f"Bearer {token}", "Accept": OCI_ACCEPT}
+    manifest, _ = _request_json(
+        f"https://{registry}/v2/{image}/manifests/{urllib.parse.quote(tag, safe='')}",
+        headers,
+    )
+    layers = manifest.get("layers") or []
+    if len(layers) != 1:
+        raise RuntimeProvisionError(
+            f"Runtime artifact {repository}:{tag} must contain exactly one layer."
+        )
+    layer = layers[0]
+    digest = str(layer.get("digest", ""))
+    if not digest.startswith("sha256:"):
+        raise RuntimeProvisionError(f"Runtime artifact {repository}:{tag} has no SHA-256 digest.")
+    size = int(layer.get("size", 0))
+    url = f"https://{registry}/v2/{image}/blobs/{digest}"
+    return url, size, digest.split(":", 1)[1]
+
+
+def _download(url: str, destination: Path, expected_size: int, expected_sha256: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_suffix(destination.suffix + ".part")
+    existing = partial.stat().st_size if partial.exists() else 0
+    headers = {"Range": f"bytes={existing}-"} if existing else {}
+    if "ghcr.io/" in url:
+        repository = load_runtime_manifest()["repository"]
+        headers["Authorization"] = f"Bearer {_oci_bearer_token(repository)}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            resumed = bool(existing and getattr(response, "status", None) == 206)
+            if existing and not resumed:
+                existing = 0
+            mode = "ab" if resumed else "wb"
+            handle = partial.open(mode)
+            try:
+                total = expected_size or int(response.headers.get("Content-Length", 0)) + existing
+                downloaded = existing
+                last_report = -1
+                while True:
+                    chunk = response.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+                    downloaded += len(chunk)
+                    percent = int(downloaded * 100 / total) if total else 0
+                    if percent >= last_report + 5:
+                        print(f"Preparing fp-tools runtime: {percent}%", flush=True)
+                        last_report = percent
+            finally:
+                handle.close()
+    except Exception as exc:
+        raise RuntimeProvisionError(
+            "Runtime download was interrupted; rerun the command to resume."
+        ) from exc
+    if expected_size and partial.stat().st_size != expected_size:
+        raise RuntimeProvisionError(
+            f"Runtime download size mismatch: expected {expected_size}, got {partial.stat().st_size}."
+        )
+    digest = hashlib.sha256()
+    with partial.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    if digest.hexdigest() != expected_sha256:
+        partial.unlink(missing_ok=True)
+        raise RuntimeProvisionError("Runtime checksum verification failed; the partial download was removed.")
+    os.replace(partial, destination)
+
+
+def _safe_extract(archive: Path, destination: Path) -> None:
+    destination_resolved = destination.resolve()
+    with tarfile.open(archive, "r:gz") as handle:
+        for member in handle.getmembers():
+            target = (destination / member.name).resolve()
+            if destination_resolved != target and destination_resolved not in target.parents:
+                raise RuntimeProvisionError(f"Unsafe path in runtime archive: {member.name}")
+            if member.issym() or member.islnk():
+                link_target = (target.parent / member.linkname).resolve()
+                if destination_resolved != link_target and destination_resolved not in link_target.parents:
+                    raise RuntimeProvisionError(f"Unsafe link in runtime archive: {member.name}")
+        try:
+            handle.extractall(destination, filter="fully_trusted")
+        except TypeError:  # Python versions before tarfile extraction filters.
+            handle.extractall(destination)
+
+
+@contextmanager
+def _install_lock(path: Path, timeout: float = 600.0):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, f"{os.getpid()}\n".encode())
+            os.close(fd)
+            break
+        except FileExistsError:
+            try:
+                if time.time() - path.stat().st_mtime > 7200:
+                    path.unlink()
+                    continue
+            except FileNotFoundError:
+                continue
+            if time.monotonic() >= deadline:
+                raise RuntimeProvisionError("Timed out waiting for another runtime installation.")
+            time.sleep(0.25)
+    try:
+        yield
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _free_space_check(path: Path, required_bytes: int) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    free = shutil.disk_usage(path).free
+    required = max(required_bytes * 3, 512 * 1024 * 1024)
+    if free < required:
+        raise RuntimeProvisionError(
+            f"Insufficient disk space for the fp-tools runtime: need approximately "
+            f"{required / 1024**3:.1f} GiB, available {free / 1024**3:.1f} GiB."
+        )
+
+
+def ensure_native_runtime(component: str = "core") -> RuntimeActivation:
+    target = platform_key()
+    if target.startswith("windows-"):
+        return ensure_wsl_runtime(component)
+    spec = _runtime_spec(component, target)
+    root = runtime_cache_root() / spec["runtime_version"] / target
+    prefix = root / component
+    ready = prefix / ".fp-tools-runtime.json"
+    if ready.is_file():
+        return RuntimeActivation("managed", component, prefix=prefix)
+    with _install_lock(root / f".{component}.lock"):
+        if ready.is_file():
+            return RuntimeActivation("managed", component, prefix=prefix)
+        url, size, digest = _resolve_oci_layer(spec["repository"], spec["tag"])
+        _free_space_check(root, size)
+        archive = root / f"{component}.tar.gz"
+        _download(url, archive, size, digest)
+        temporary = Path(tempfile.mkdtemp(prefix=f".{component}-", dir=root))
+        try:
+            _safe_extract(archive, temporary)
+            python = temporary / "bin" / "python"
+            unpack = temporary / "bin" / "conda-unpack"
+            if python.is_file() and unpack.is_file():
+                result = subprocess.run([str(python), str(unpack)], check=False)
+                if result.returncode:
+                    raise RuntimeProvisionError("The downloaded runtime could not be relocated.")
+            missing = [name for name in spec["commands"] if not (temporary / "bin" / name).exists()]
+            if missing:
+                raise RuntimeProvisionError(
+                    f"The downloaded runtime is missing: {', '.join(missing)}"
+                )
+            (temporary / ".fp-tools-runtime.json").write_text(
+                json.dumps(
+                    {
+                        "runtime_version": spec["runtime_version"],
+                        "component": component,
+                        "platform": target,
+                        "sha256": digest,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            if prefix.exists():
+                shutil.rmtree(prefix)
+            os.replace(temporary, prefix)
+        finally:
+            if temporary.exists():
+                shutil.rmtree(temporary, ignore_errors=True)
+            archive.unlink(missing_ok=True)
+    return RuntimeActivation("managed", component, prefix=prefix)
+
+
+def activate_runtime(component: str = "core", mode: str | None = None) -> RuntimeActivation:
+    resolved = _runtime_mode(mode)
+    if resolved == "system":
+        return RuntimeActivation("system", component)
+    if resolved == "container":
+        return RuntimeActivation("container", component)
+    activation = ensure_native_runtime(component)
+    if activation.prefix is not None:
+        bin_dir = activation.prefix / ("Scripts" if os.name == "nt" else "bin")
+        os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+        os.environ["FP_TOOLS_RUNTIME_PREFIX"] = str(activation.prefix)
+    return activation
+
+
+def _wsl_name(version: str) -> str:
+    safe = "".join(ch if ch.isalnum() else "-" for ch in version).strip("-")
+    return f"fp-tools-{safe}"
+
+
+def _wsl_distributions() -> set[str]:
+    result = subprocess.run(
+        ["wsl.exe", "--list", "--quiet"], capture_output=True, text=True, check=False
+    )
+    text = (result.stdout or "").replace("\x00", "")
+    return {line.strip() for line in text.splitlines() if line.strip()}
+
+
+def _enable_wsl() -> None:
+    if shutil.which("wsl.exe"):
+        status = subprocess.run(["wsl.exe", "--status"], capture_output=True, check=False)
+        if status.returncode == 0:
+            return
+    powershell = shutil.which("powershell.exe") or shutil.which("powershell")
+    if not powershell:
+        raise RuntimeProvisionError("Windows Subsystem for Linux is unavailable on this system.")
+    command = (
+        "Start-Process wsl.exe -Verb RunAs -Wait "
+        "-ArgumentList '--install','--no-distribution'"
+    )
+    result = subprocess.run([powershell, "-NoProfile", "-Command", command], check=False)
+    if result.returncode:
+        raise RuntimeProvisionError("Windows did not enable WSL2.")
+    raise RuntimeProvisionError(
+        "WSL2 was enabled. Restart Windows if requested, then open fp-tools again; setup will resume automatically."
+    )
+
+
+def ensure_wsl_runtime(component: str = "core") -> RuntimeActivation:
+    if os.name != "nt":
+        raise RuntimeProvisionError("The WSL runtime can only be provisioned from Windows.")
+    _enable_wsl()
+    target = platform_key()
+    spec = _runtime_spec(component, target)
+    distro = _wsl_name(spec["runtime_version"])
+    if distro in _wsl_distributions():
+        return RuntimeActivation("managed", component, distro=distro)
+    root = runtime_cache_root() / spec["runtime_version"] / target
+    install_dir = root / "wsl"
+    with _install_lock(root / ".wsl.lock"):
+        if distro in _wsl_distributions():
+            return RuntimeActivation("managed", component, distro=distro)
+        url, size, digest = _resolve_oci_layer(spec["repository"], spec["tag"])
+        _free_space_check(root, size)
+        archive = root / "fp-tools-wsl-rootfs.tar.gz"
+        _download(url, archive, size, digest)
+        install_dir.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(
+            [
+                "wsl.exe",
+                "--import",
+                distro,
+                str(install_dir),
+                str(archive),
+                "--version",
+                "2",
+            ],
+            check=False,
+        )
+        if result.returncode:
+            raise RuntimeProvisionError("Windows could not import the fp-tools WSL runtime.")
+        archive.unlink(missing_ok=True)
+    return RuntimeActivation("managed", component, distro=distro)
+
+
+def _looks_like_url(value: str) -> bool:
+    return urllib.parse.urlparse(value).scheme in {"http", "https", "ftp", "s3"}
+
+
+def _replace_runtime_option(arguments: list[str], value: str) -> list[str]:
+    output: list[str] = []
+    skip = False
+    for index, argument in enumerate(arguments):
+        if skip:
+            skip = False
+            continue
+        if argument == "--runtime":
+            skip = True
+            continue
+        if argument.startswith("--runtime="):
+            continue
+        output.append(argument)
+    output.extend(["--runtime", value])
+    return output
+
+
+def _wsl_path(distro: str, value: str) -> str:
+    if _looks_like_url(value):
+        return value
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    result = subprocess.run(
+        ["wsl.exe", "--distribution", distro, "--exec", "wslpath", "-a", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise RuntimeProvisionError(f"Could not translate Windows path for WSL: {value}")
+    return result.stdout.strip()
+
+
+def translate_flag_paths(
+    arguments: Sequence[str], path_flags: Iterable[str], translator
+) -> list[str]:
+    path_flags = set(path_flags)
+    translated: list[str] = []
+    index = 0
+    arguments = list(map(str, arguments))
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument in path_flags and index + 1 < len(arguments):
+            translated.append(argument)
+            index += 1
+            while index < len(arguments) and not arguments[index].startswith("--"):
+                translated.append(translator(arguments[index]))
+                index += 1
+            continue
+        matched = next((flag for flag in path_flags if argument.startswith(flag + "=")), None)
+        if matched:
+            translated.append(matched + "=" + translator(argument.split("=", 1)[1]))
+        else:
+            translated.append(argument)
+        index += 1
+    return translated
+
+
+def run_managed_wsl_command(
+    command: str,
+    arguments: Sequence[str],
+    path_flags: Iterable[str],
+    component: str = "core",
+) -> int:
+    activation = ensure_wsl_runtime(component)
+    assert activation.distro is not None
+    translated = translate_flag_paths(
+        _replace_runtime_option(list(arguments), "system"),
+        path_flags,
+        lambda value: _wsl_path(activation.distro or "", value),
+    )
+    cwd = _wsl_path(activation.distro, str(Path.cwd()))
+    executable = f"/opt/conda/bin/{command}"
+    result = subprocess.run(
+        [
+            "wsl.exe",
+            "--distribution",
+            activation.distro,
+            "--cd",
+            cwd,
+            "--exec",
+            executable,
+            *translated,
+        ],
+        check=False,
+    )
+    return int(result.returncode)
+
+
+def run_container_command(
+    command: str,
+    arguments: Sequence[str],
+    path_flags: Iterable[str],
+) -> int:
+    """Run one fp-tools command in the complete public container."""
+
+    docker = shutil.which("docker")
+    if not docker:
+        raise RuntimeProvisionError(
+            "Container runtime requested, but Docker is not installed or not available on PATH."
+        )
+    cwd = Path.cwd().resolve()
+    mounts: dict[Path, str] = {cwd: "/work"}
+
+    def translate(value: str) -> str:
+        if _looks_like_url(value) or value in {"hg38", "mm10"}:
+            return value
+        path = Path(value).expanduser()
+        if not path.is_absolute():
+            path = (cwd / path).resolve()
+        try:
+            return str(Path("/work") / path.relative_to(cwd))
+        except ValueError:
+            parent = path if path.exists() and path.is_dir() else path.parent
+            parent = parent.resolve()
+            target = mounts.setdefault(parent, f"/fp-tools-mount/{len(mounts)}")
+            return target if path == parent else str(Path(target) / path.name)
+
+    translated = translate_flag_paths(
+        _replace_runtime_option(list(arguments), "system"), path_flags, translate
+    )
+    image = os.environ.get(
+        "FP_TOOLS_CONTAINER_IMAGE", f"ghcr.io/oncologylab/fp-tools:v{__version__}"
+    )
+    invocation = [docker, "run", "--rm"]
+    if os.name != "nt" and hasattr(os, "getuid"):
+        invocation.extend(["--user", f"{os.getuid()}:{os.getgid()}", "-e", "HOME=/tmp"])
+    for source, target in mounts.items():
+        invocation.extend(["-v", f"{source}:{target}"])
+    invocation.extend(["-w", "/work", image, command, *translated])
+    return int(subprocess.run(invocation, check=False).returncode)
+
+
+def prepare_command_runtime(
+    command: str,
+    arguments: Sequence[str],
+    mode: str | None,
+    component: str,
+    path_flags: Iterable[str],
+) -> int | None:
+    """Prepare a runtime or delegate the complete command when required."""
+
+    resolved = _runtime_mode(mode)
+    if resolved == "container":
+        return run_container_command(command, arguments, path_flags)
+    if resolved == "managed" and os.name == "nt":
+        return run_managed_wsl_command(command, arguments, path_flags, component)
+    activate_runtime(component, resolved)
+    return None
+
+
+def runtime_status() -> list[dict[str, str]]:
+    manifest = load_runtime_manifest()
+    target = platform_key()
+    rows = []
+    for component in manifest["components"]:
+        available = component in manifest.get("artifacts", {}).get(target, {})
+        if target.startswith("windows-"):
+            installed = _wsl_name(manifest["runtime_version"]) in _wsl_distributions() if shutil.which("wsl.exe") else False
+            location = _wsl_name(manifest["runtime_version"])
+        else:
+            location_path = runtime_cache_root() / manifest["runtime_version"] / target / component
+            installed = (location_path / ".fp-tools-runtime.json").is_file()
+            location = str(location_path)
+        rows.append(
+            {
+                "component": component,
+                "platform": target,
+                "available": "yes" if available else "no",
+                "installed": "yes" if installed else "no",
+                "location": location,
+            }
+        )
+    return rows

--- a/src/fp_tools/tools/bulk_footprinting.py
+++ b/src/fp_tools/tools/bulk_footprinting.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shlex
 import subprocess
 import sys
 from pathlib import Path
 
+from fp_tools.runtime import RuntimeProvisionError, add_runtime_argument, prepare_command_runtime
 from fp_tools.utils.project_layout import (
     analysis_peaks_path,
     comparison_dir,
@@ -157,13 +159,117 @@ def build_commands(args: argparse.Namespace) -> list[tuple[str, list[str]]]:
     return commands
 
 
+def build_prepare_command(args: argparse.Namespace) -> list[str]:
+    """Build the raw-read preparation stage used by the end-to-end wrapper."""
+
+    command = [
+        "prepare-atac",
+        "--samples",
+        str(args.reads_table),
+        "--genome",
+        str(args.genome),
+        "--outdir",
+        str(Path(args.outdir).expanduser().resolve()),
+        "--cores",
+        str(args.cores),
+        "--runtime",
+        "system",
+    ]
+    scalar_options = {
+        "config": "--config",
+        "profile": "--profile",
+        "reference_dir": "--reference-dir",
+        "fasta": "--fasta",
+        "bowtie2_index": "--bowtie2-index",
+        "blacklist": "--blacklist",
+        "tss": "--tss",
+        "macs_genome_size": "--macs-genome-size",
+        "max_parallel_samples": "--max-parallel-samples",
+        "memory_gb": "--memory-gb",
+    }
+    for attribute, flag in scalar_options.items():
+        value = getattr(args, attribute, None)
+        if value is not None:
+            command.extend([flag, str(value)])
+    if args.keep_intermediates:
+        command.append("--keep-intermediates")
+    if args.force:
+        command.append("--no-resume")
+    if args.fail_fast:
+        command.append("--fail-fast")
+    return command
+
+
+def _prepared_inputs(project: Path) -> tuple[Path, str, str | None]:
+    sample_table = project / "metadata" / "samples.tsv"
+    reference_path = project / "metadata" / "reference.json"
+    if not sample_table.is_file() or not reference_path.is_file():
+        raise ValueError(
+            "Raw-read preparation did not produce metadata/samples.tsv and metadata/reference.json"
+        )
+    reference = json.loads(reference_path.read_text(encoding="utf-8"))
+    genome = str(reference.get("fasta") or "")
+    if not genome:
+        raise ValueError("The prepared reference metadata does not contain a genome FASTA")
+    blacklist = str(reference.get("blacklist") or "") or None
+    return sample_table, genome, blacklist
+
+
+def _planned_prepared_inputs(args: argparse.Namespace, project: Path) -> argparse.Namespace:
+    """Resolve predictable downstream paths without creating or downloading data."""
+
+    planned = argparse.Namespace(**vars(args))
+    planned.sample_table = str(project / "metadata" / "samples.tsv")
+    reference_root = Path(
+        args.reference_dir or Path.home() / ".cache" / "fp-tools" / "references"
+    ).expanduser()
+    planned.genome = str(
+        Path(args.fasta).expanduser().resolve()
+        if args.fasta
+        else reference_root / str(args.genome) / f"{args.genome}.fa"
+    )
+    if args.blacklist:
+        planned.blacklist = str(Path(args.blacklist).expanduser().resolve())
+    elif args.genome in {"hg38", "mm10"}:
+        planned.blacklist = str(
+            reference_root / str(args.genome) / f"{args.genome}.blacklist.bed"
+        )
+    else:
+        planned.blacklist = None
+    return planned
+
+
 def run_bulk_footprinting(args: argparse.Namespace) -> int:
     project = Path(args.outdir).expanduser().resolve()
     project.mkdir(parents=True, exist_ok=True)
     log_dir = project / "logs" / "bulk_footprinting"
     log_dir.mkdir(parents=True, exist_ok=True)
-    samples = read_sample_table(args.sample_table)
     comparisons = read_comparison_table(args.comparison_table)
+    prepare_command = None
+    if args.reads_table:
+        prepare_command = build_prepare_command(args)
+        if args.dry_run:
+            print(f"[prepare-atac] {_quote([*prepare_command, '--dry-run'])}")
+            for label, command in build_commands(_planned_prepared_inputs(args, project)):
+                print(f"[{label}] {_quote(command)}")
+            return 0
+        if not (args.resume and not args.force and (project / "metadata" / "samples.tsv").is_file()):
+            code = _run(
+                prepare_command,
+                log_dir / "prepare-atac.stdout.log",
+                log_dir / "prepare-atac.stderr.log",
+            )
+            if code:
+                print(f"prepare-atac failed with exit code {code}; see {log_dir}", file=sys.stderr)
+                return code
+        else:
+            print("[resume] prepare-atac: complete")
+        sample_table, genome, blacklist = _prepared_inputs(project)
+        args.sample_table = str(sample_table)
+        args.genome = genome
+        args.blacklist = blacklist
+
+    samples = read_sample_table(args.sample_table)
     conditions = {row.condition for row in samples}
     unknown = sorted({value for row in comparisons for value in (row.cond1, row.cond2)} - conditions)
     if unknown:
@@ -173,7 +279,8 @@ def run_bulk_footprinting(args: argparse.Namespace) -> int:
     commands = build_commands(args)
     command_file = log_dir / "bulk_footprinting_commands.sh"
     lines = ["#!/usr/bin/env bash", "set -euo pipefail", "", "# Generated by bulk-footprinting.", ""]
-    for label, command in commands:
+    logged_commands = ([('prepare-atac', prepare_command)] if prepare_command else []) + commands
+    for label, command in logged_commands:
         lines.extend([f"# {label}", _quote(command), ""])
     command_file.write_text("\n".join(lines), encoding="utf-8")
     command_file.chmod(0o755)
@@ -205,10 +312,25 @@ def run_bulk_footprinting(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bulk-footprinting", description=__doc__)
-    parser.add_argument("--sample-table", required=True, help="TSV with sample, condition, BAM, and peak BED columns.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--sample-table", help="TSV with sample, condition, BAM, and peak BED columns.")
+    source.add_argument(
+        "--reads-table",
+        help="TSV/CSV with local FASTQ paths or public run accessions; runs preparation before footprinting.",
+    )
     parser.add_argument("--comparison-table", required=True, help="TSV with comparison, cond1, and cond2 columns.")
-    parser.add_argument("--genome", required=True, help="Reference genome FASTA.")
+    parser.add_argument("--genome", required=True, help="Reference FASTA for aligned input, or hg38/mm10/custom label for raw reads.")
     parser.add_argument("--blacklist", help="Optional blacklist BED used during bias correction.")
+    parser.add_argument("--config", help="Optional prepare-atac YAML for raw reads.")
+    parser.add_argument("--profile", choices=["modern", "homer-atac"], default="modern", help="Raw-read processing profile (default: modern).")
+    parser.add_argument("--reference-dir", help="Reference cache root for raw reads.")
+    parser.add_argument("--fasta", help="Custom reference FASTA for raw reads.")
+    parser.add_argument("--bowtie2-index", help="Existing Bowtie2 index prefix for raw reads.")
+    parser.add_argument("--tss", help="Optional TSS BED for raw-read QC.")
+    parser.add_argument("--macs-genome-size", help="MACS3 genome size for a custom genome.")
+    parser.add_argument("--max-parallel-samples", type=int, help="Maximum raw-read samples processed concurrently.")
+    parser.add_argument("--memory-gb", type=float, help="Total memory budget for raw-read processing.")
+    parser.add_argument("--keep-intermediates", action="store_true", help="Keep raw-read intermediate files.")
     parser.add_argument("--motifs", nargs="*", help="Optional motif files.")
     parser.add_argument("--motif-db", default="jaspar2026_vertebrates", help="Built-in motif database (default: jaspar2026_vertebrates).")
     parser.add_argument("--normalization", choices=["none", "condition-quantile", "sample-quantile"], default="none", help="Differential-stage normalization (default: none).")
@@ -220,17 +342,44 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--force", action="store_true", help="Rerun stages even when outputs already exist.")
     parser.add_argument("--dry-run", action="store_true", help="Validate inputs and print the commands without running them.")
     parser.add_argument("--fail-fast", action="store_true", help="Stop at the first failed stage.")
+    add_runtime_argument(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
+    raw_args = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_args)
     if args.resume and args.force:
         parser.error("--resume and --force are mutually exclusive")
     try:
+        if args.reads_table and not args.dry_run:
+            delegated = prepare_command_runtime(
+                "bulk-footprinting",
+                raw_args,
+                args.runtime,
+                "core",
+                {
+                    "--sample-table",
+                    "--reads-table",
+                    "--comparison-table",
+                    "--genome",
+                    "--blacklist",
+                    "--config",
+                    "--reference-dir",
+                    "--fasta",
+                    "--bowtie2-index",
+                    "--tss",
+                    "--outdir",
+                    "--motifs",
+                },
+            )
+            if delegated is not None:
+                return delegated
+            if args.profile == "homer-atac":
+                prepare_command_runtime("bulk-footprinting", raw_args, args.runtime, "homer", set())
         return run_bulk_footprinting(args)
-    except ValueError as exc:
+    except (ValueError, RuntimeProvisionError) as exc:
         parser.error(str(exc))
 
 

--- a/src/fp_tools/tools/diff_footprint_helpers.py
+++ b/src/fp_tools/tools/diff_footprint_helpers.py
@@ -444,8 +444,19 @@ def process_tfbs(TF_name, args, log2fc_params, bed_rows=None):
                                                                        subset.iloc[:, 2].values)]
             observed_log2fcs = subset.groupby('peak_id')[base + '_log2fc'].mean().reset_index()[base + "_log2fc"].values
             observed_deltas = subset.groupby('peak_id')[base + '_delta_fp'].mean().reset_index()[base + "_delta_fp"].values
-            info_table.at[TF_name, base + "_mean_delta_fp"] = np.round(float(np.mean(observed_deltas)), 5) if len(observed_deltas) else np.nan
-            info_table.at[TF_name, base + "_mean_log2fc"] = np.round(float(np.mean(observed_log2fcs)), 5) if len(observed_log2fcs) else np.nan
+            if len(observed_log2fcs) == 0:
+                # Motif sites can exist while every compared score is zero.
+                # There is no evidence of a differential footprint in that
+                # case, and attempting a distribution fit would emit warnings
+                # and propagate NaN values into comparison-wide thresholds.
+                info_table.at[TF_name, base + "_mean_delta_fp"] = 0.0
+                info_table.at[TF_name, base + "_mean_log2fc"] = 0.0
+                info_table.at[TF_name, base + "_change"] = 0.0
+                info_table.at[TF_name, base + "_pvalue"] = 1.0
+                continue
+
+            info_table.at[TF_name, base + "_mean_delta_fp"] = np.round(float(np.mean(observed_deltas)), 5)
+            info_table.at[TF_name, base + "_mean_log2fc"] = np.round(float(np.mean(observed_log2fcs)), 5)
             n1 = max(1, args.condition_replicates.get(cond1, 1))
             n2 = max(1, args.condition_replicates.get(cond2, 1))
             sd1 = pd.to_numeric(subset[cond1 + "_score_sd"], errors="coerce").to_numpy(dtype=float)
@@ -535,8 +546,10 @@ def plot_diff_footprints(motifs, cluster_obj, conditions, args):
         for m in motifs
     }
 
-    xvalues = np.array([v["change"] for v in diff_scores.values()])
-    yvalues = np.array([v["log10pvalue"] for v in diff_scores.values()])
+    xvalues = np.array([v["change"] for v in diff_scores.values()], dtype=float)
+    yvalues = np.array([v["log10pvalue"] for v in diff_scores.values()], dtype=float)
+    xvalues = np.where(np.isfinite(xvalues), xvalues, 0.0)
+    yvalues = np.where(np.isfinite(yvalues), yvalues, 0.0)
 
     y_min = np.percentile(yvalues[yvalues < -np.log10(1e-300)], 95) if (yvalues < -np.log10(1e-300)).any() else np.percentile(yvalues, 95)
     x_min, x_max = np.percentile(xvalues, [5, 95])

--- a/src/fp_tools/tools/diff_footprints.py
+++ b/src/fp_tools/tools/diff_footprints.py
@@ -109,6 +109,27 @@ def _benjamini_hochberg(pvalues):
     return qvals
 
 
+def _finite_highlight_thresholds(changes, pvalues):
+    """Return robust percentile thresholds for motif highlighting."""
+
+    change_values = np.asarray(changes, dtype=float)
+    pvalue_values = np.asarray(pvalues, dtype=float)
+    finite_changes = change_values[np.isfinite(change_values)]
+    finite_positive_pvalues = pvalue_values[
+        np.isfinite(pvalue_values) & (pvalue_values > 0)
+    ]
+    if finite_changes.size:
+        change_min, change_max = np.percentile(finite_changes, [5, 95])
+    else:
+        change_min, change_max = 0.0, 0.0
+    pvalue_min = (
+        float(np.percentile(finite_positive_pvalues, 5))
+        if finite_positive_pvalues.size
+        else 1.0
+    )
+    return float(change_min), float(change_max), pvalue_min
+
+
 def _apply_replicate_empirical_bayes(info_table, args):
     """Add replicate-level moderated contrasts and write their source matrix."""
 
@@ -568,16 +589,30 @@ def _existing_result_motifs(info_table, comparison, args, motif_lookup=None):
         )
 
     rows = info_table.copy()
-    rows[base + "_change_numeric"] = pd.to_numeric(rows[base + "_change"], errors="coerce").fillna(0.0)
-    rows[base + "_pvalue_numeric"] = pd.to_numeric(rows[base + "_pvalue"], errors="coerce").fillna(1.0)
+    rows[base + "_change_numeric"] = (
+        pd.to_numeric(rows[base + "_change"], errors="coerce")
+        .replace([np.inf, -np.inf], np.nan)
+        .fillna(0.0)
+    )
+    rows[base + "_pvalue_numeric"] = (
+        pd.to_numeric(rows[base + "_pvalue"], errors="coerce")
+        .replace([np.inf, -np.inf], np.nan)
+        .fillna(1.0)
+        .clip(0.0, 1.0)
+    )
     qvalue_col = base + "_qvalue_bh"
     if qvalue_col in rows.columns:
-        rows[base + "_qvalue_numeric"] = pd.to_numeric(rows[qvalue_col], errors="coerce").fillna(1.0)
+        rows[base + "_qvalue_numeric"] = (
+            pd.to_numeric(rows[qvalue_col], errors="coerce")
+            .replace([np.inf, -np.inf], np.nan)
+            .fillna(1.0)
+            .clip(0.0, 1.0)
+        )
     else:
         rows[base + "_qvalue_numeric"] = _benjamini_hochberg(rows[base + "_pvalue_numeric"].to_numpy())
-    filtered_p = rows.loc[rows[base + "_pvalue_numeric"] > 0, base + "_pvalue_numeric"]
-    pval_min = np.percentile(filtered_p, 5) if len(filtered_p) else 1.0
-    change_min, change_max = np.percentile(rows[base + "_change_numeric"], [5, 95]) if len(rows) else (0.0, 0.0)
+    change_min, change_max, pval_min = _finite_highlight_thresholds(
+        rows[base + "_change_numeric"], rows[base + "_pvalue_numeric"]
+    )
 
     motifs = []
     for _, row in rows.iterrows():
@@ -2594,18 +2629,28 @@ def run_diff_footprints(args):
     for (c1, c2) in comparisons:
         base = f"{c1}_{c2}"
         info_table[base + "_change"] = info_table[base + "_change"].astype(float).round(5)
-        raw_pvals = pd.to_numeric(info_table[base + "_pvalue"], errors="coerce").fillna(1.0).astype(float)
+        raw_pvals = (
+            pd.to_numeric(info_table[base + "_pvalue"], errors="coerce")
+            .replace([np.inf, -np.inf], np.nan)
+            .fillna(1.0)
+            .clip(0.0, 1.0)
+            .astype(float)
+        )
         qvals = _benjamini_hochberg(raw_pvals.to_numpy())
         info_table[base + "_pvalue"] = raw_pvals.map("{:.5E}".format, na_action="ignore")
         info_table[base + "_qvalue_bh"] = pd.Series(qvals, index=info_table.index).map("{:.5E}".format, na_action="ignore")
         info_table[base + "_significant_fdr05"] = pd.Series(qvals <= 0.05, index=info_table.index).fillna(False).astype(bool)
 
         names_series = info_table["output_prefix"]
-        changes = info_table[base + "_change"].astype(float)
+        changes = (
+            pd.to_numeric(info_table[base + "_change"], errors="coerce")
+            .replace([np.inf, -np.inf], np.nan)
+            .fillna(0.0)
+            .astype(float)
+        )
+        info_table[base + "_change"] = changes.round(5)
         pvals = raw_pvals
-        filtered_p = pvals[pvals > 0]
-        pval_min = np.percentile(filtered_p, 5) if len(filtered_p) >= 1 else 1.0
-        change_min, change_max = np.percentile(changes, [5, 95])
+        change_min, change_max, pval_min = _finite_highlight_thresholds(changes, pvals)
 
         for i, (chg, p) in enumerate(zip(changes, pvals)):
             # info_table.at[names_series[i], base + "_highlighted"] = (chg < change_min) or (chg > change_max) or (p < pval_min)

--- a/src/fp_tools/tools/motif_discovery.py
+++ b/src/fp_tools/tools/motif_discovery.py
@@ -16,6 +16,11 @@ from pathlib import Path
 
 from Bio import SeqIO
 
+from fp_tools.runtime import (
+    RuntimeProvisionError,
+    add_runtime_argument,
+    prepare_command_runtime,
+)
 from fp_tools.utils.motif_databases import motif_db_table, resolve_motif_inputs
 
 
@@ -404,7 +409,29 @@ def motif_discovery_plan_main(argv: list[str] | None = None) -> int:
     parser.add_argument("--list-motif-dbs", action="store_true", help="List available built-in motif databases and exit.")
     parser.add_argument("--extra-args", nargs=argparse.REMAINDER, default=[], help="Additional arguments appended to MEME/DREME/STREME.")
     parser.add_argument("--execute", action="store_true", help="Run the generated script immediately.")
+    add_runtime_argument(parser)
     args = parser.parse_args(argv)
+
+    if args.execute:
+        try:
+            delegated = prepare_command_runtime(
+                "discover-motifs",
+                list(raw_args),
+                args.runtime,
+                "meme",
+                {
+                    "--fasta",
+                    "--candidates",
+                    "--genome",
+                    "--outdir",
+                    "--script",
+                    "--known-motifs",
+                },
+            )
+            if delegated is not None:
+                return delegated
+        except RuntimeProvisionError as exc:
+            parser.exit(2, f"discover-motifs: runtime error: {exc}\n")
 
     outdir = Path(args.outdir)
     if args.candidates:

--- a/src/fp_tools/tools/prepare_atac.py
+++ b/src/fp_tools/tools/prepare_atac.py
@@ -27,6 +27,12 @@ from typing import Any, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from fp_tools.utils import bigwig as pyBigWig
+from fp_tools.runtime import (
+    RuntimeProvisionError,
+    activate_runtime,
+    add_runtime_argument,
+    prepare_command_runtime,
+)
 try:
     import pysam
 except ImportError:  # Raw-read preparation is documented through WSL on Windows.
@@ -1822,17 +1828,29 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Write the fully documented default YAML and exit.",
     )
+    add_runtime_argument(parser)
     return parser
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> int:
+    raw_args = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
-    args = parser.parse_args()
-    if args.doctor:
-        raise SystemExit(doctor(args.profile or "modern"))
+    args = parser.parse_args(raw_args)
     if args.write_default_config:
         print(write_default_config(args.write_default_config, args.profile or "modern"))
-        return
+        return 0
+    if args.doctor:
+        try:
+            delegated = prepare_command_runtime(
+                "prepare-atac", raw_args, args.runtime, "core", set()
+            )
+            if delegated is not None:
+                return delegated
+            if normalize_profile(args.profile or "modern") == "homer-atac":
+                activate_runtime("homer", args.runtime)
+        except RuntimeProvisionError as exc:
+            parser.exit(2, f"prepare-atac: runtime error: {exc}\n")
+        return doctor(args.profile or "modern")
     missing = [
         flag for flag in ("samples", "genome", "outdir") if not getattr(args, flag)
     ]
@@ -1841,8 +1859,29 @@ def main() -> None:
             "the following arguments are required for a run: "
             + ", ".join("--" + value for value in missing)
         )
+    if not args.dry_run:
+        path_flags = {
+            "--samples",
+            "--outdir",
+            "--config",
+            "--reference-dir",
+            "--fasta",
+            "--bowtie2-index",
+            "--blacklist",
+            "--tss",
+        }
+        try:
+            delegated = prepare_command_runtime(
+                "prepare-atac", raw_args, args.runtime, "core", path_flags
+            )
+            if delegated is not None:
+                return delegated
+            if normalize_profile(args.profile or "modern") == "homer-atac":
+                activate_runtime("homer", args.runtime)
+        except RuntimeProvisionError as exc:
+            parser.exit(2, f"prepare-atac: runtime error: {exc}\n")
     try:
-        raise SystemExit(run_preprocessing(args))
+        return run_preprocessing(args)
     except (
         ValueError,
         RuntimeError,
@@ -1850,7 +1889,8 @@ def main() -> None:
         subprocess.CalledProcessError,
     ) as exc:
         parser.exit(2, f"prepare-atac: error: {exc}\n")
+    return 2
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/fp_tools/utils/regions.py
+++ b/src/fp_tools/utils/regions.py
@@ -611,7 +611,7 @@ class RegionList(list):
 
 				#Do the regions overlap?
 				if s1_chrom == s2_chrom:
-					if s1_start < s2_end and s1_end > s2_start+1:	#if overlap
+					if s1_start < s2_end and s1_end > s2_start:	#if overlap
 						bp_overlap = min([s1_end, s2_end]) - max([s1_start, s2_start]) 
 						overlap[(s1_id, s2_id)] = overlap.get((s1_id, s2_id), 0) + bp_overlap
 						overlap[(s2_id, s1_id)] = overlap.get((s2_id, s1_id), 0) + bp_overlap

--- a/tests/test_cli_and_config_smoke.py
+++ b/tests/test_cli_and_config_smoke.py
@@ -20,6 +20,23 @@ CONFIG_DIR = ROOT / "examples" / "gui_configs"
 
 
 class CliAndConfigSmokeTest(unittest.TestCase):
+    def test_bulk_config_accepts_exactly_one_input_level(self):
+        base = {
+            "tool": "bulk-footprinting",
+            "comparison_table": "comparisons.tsv",
+            "genome": "hg38",
+            "outdir": "results",
+        }
+        raw = {"samples": [{**base, "reads_table": "reads.tsv"}], "comparisons": []}
+        aligned = {"samples": [{**base, "sample_table": "samples.tsv"}], "comparisons": []}
+        both = {
+            "samples": [{**base, "reads_table": "reads.tsv", "sample_table": "samples.tsv"}],
+            "comparisons": [],
+        }
+        self.assertEqual(validate_config(raw), [])
+        self.assertEqual(validate_config(aligned), [])
+        self.assertTrue(any("exactly one" in value for value in validate_config(both)))
+
     def test_region_comparison_yaml_does_not_require_peaks(self):
         config = {
             "version": 1,
@@ -114,6 +131,7 @@ class CliAndConfigSmokeTest(unittest.TestCase):
             "plot-aggregate",
             "review-multi-comparisons",
             "bulk-footprinting",
+            "fp-tools-runtime",
             "run-yaml-workflow",
             "discover-motifs",
             "summarize-motifs",

--- a/tests/test_diff_footprint_statistics.py
+++ b/tests/test_diff_footprint_statistics.py
@@ -1,11 +1,13 @@
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 
 from fp_tools.tools import diff_footprint_helpers
+from fp_tools.tools.diff_footprints import _finite_highlight_thresholds
 
 
 class DifferentialFootprintStatisticsTest(unittest.TestCase):
@@ -65,6 +67,35 @@ class DifferentialFootprintStatisticsTest(unittest.TestCase):
 
         self.assertTrue(np.isfinite(float(result.at["TF1", "A_B_change"])))
         self.assertTrue(np.isfinite(float(result.at["TF1", "A_B_pvalue"])))
+
+    def test_all_zero_scores_are_neutral_without_runtime_warnings(self):
+        with tempfile.TemporaryDirectory() as tmpdir, warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = diff_footprint_helpers.process_tfbs(
+                "TF1",
+                self._args(tmpdir),
+                {("A", "B"): (0.0, 0.5)},
+                bed_rows=[self._row(0, 0.0, 0.0)],
+            )
+
+        self.assertEqual(caught, [])
+        self.assertEqual(float(result.at["TF1", "A_B_change"]), 0.0)
+        self.assertEqual(float(result.at["TF1", "A_B_pvalue"]), 1.0)
+        self.assertEqual(float(result.at["TF1", "A_B_mean_delta_fp"]), 0.0)
+        self.assertEqual(float(result.at["TF1", "A_B_mean_log2fc"]), 0.0)
+
+    def test_nonfinite_motif_cannot_poison_highlight_thresholds(self):
+        changes = np.array([np.nan, -3.0, 0.0, 4.0])
+        pvalues = np.array([1.0, 0.01, 0.5, 0.001])
+
+        change_min, change_max, pvalue_min = _finite_highlight_thresholds(
+            changes, pvalues
+        )
+
+        self.assertTrue(np.isfinite([change_min, change_max, pvalue_min]).all())
+        self.assertLess(change_min, 0.0)
+        self.assertGreater(change_max, 0.0)
+        self.assertLessEqual(pvalue_min, 0.01)
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -42,6 +42,7 @@ class GuiLauncherTests(unittest.TestCase):
             "review-multi-comparisons",
             "run-yaml-workflow",
             "fp-tools-gui",
+            "fp-tools-runtime",
             "discover-motifs",
             "summarize-motifs",
             "pseudobulk-fragments",

--- a/tests/test_public_api_aliases.py
+++ b/tests/test_public_api_aliases.py
@@ -26,6 +26,7 @@ class PublicApiAliasesTest(unittest.TestCase):
             "run-yaml-workflow": "fp_tools.cli_batch:main",
             "run-workflow": "fp_tools.cli_compat:run_workflow_main",
             "fp-tools-gui": "fp_tools.cli_gui:main",
+            "fp-tools-runtime": "fp_tools.cli_runtime:main",
             "discover-motifs": "fp_tools.tools.motif_discovery:motif_discovery_plan_main",
             "summarize-motifs": "fp_tools.tools.motif_discovery:motif_report_main",
             "motif-discovery": "fp_tools.cli_compat:motif_discovery_main",

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,6 +1,7 @@
 import unittest
+import random
 
-from fp_tools.utils.regions import OneRegion, RegionList
+from fp_tools.utils.regions import OneRegion, RegionCluster, RegionList
 
 
 class RegionListMergeTest(unittest.TestCase):
@@ -110,6 +111,61 @@ class RegionListMergeTest(unittest.TestCase):
         self.assertEqual(overlaps["B"], 6)
         self.assertEqual(overlaps[("A", "B")], 6)
         self.assertEqual(overlaps[("B", "A")], 6)
+
+    def test_count_overlaps_includes_one_base_intersection(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 5, "A"]),
+                OneRegion(["chr1", 4, 10, "B"]),
+            ]
+        )
+
+        overlaps = regions.count_overlaps()
+
+        self.assertEqual(overlaps[("A", "B")], 1)
+        self.assertEqual(overlaps[("B", "A")], 1)
+        cluster = RegionCluster(overlaps)
+        cluster.overlap_to_distance()
+        self.assertAlmostEqual(cluster.distance_mat[0, 1], 0.8)
+        self.assertAlmostEqual(cluster.distance_mat[1, 0], 0.8)
+
+    def test_count_overlaps_obeys_half_open_bed_boundaries(self):
+        regions = RegionList(
+            [
+                OneRegion(["chr1", 0, 5, "A"]),
+                OneRegion(["chr1", 5, 10, "B"]),
+                OneRegion(["chr1", 8, 12, "C"]),
+                OneRegion(["chr1", 9, 10, "D"]),
+                OneRegion(["chr2", 4, 10, "E"]),
+            ]
+        )
+
+        overlaps = regions.count_overlaps()
+
+        self.assertNotIn(("A", "B"), overlaps)
+        self.assertEqual(overlaps[("B", "C")], 2)
+        self.assertEqual(overlaps[("B", "D")], 1)
+        self.assertEqual(overlaps[("D", "B")], 1)
+        self.assertNotIn(("A", "E"), overlaps)
+
+    def test_count_overlaps_matches_randomized_half_open_intersections(self):
+        rng = random.Random(20260820)
+        for _ in range(2000):
+            start_a = rng.randrange(0, 200)
+            start_b = rng.randrange(0, 200)
+            end_a = start_a + rng.randrange(1, 30)
+            end_b = start_b + rng.randrange(1, 30)
+            regions = RegionList(
+                [
+                    OneRegion(["chr1", start_a, end_a, "A"]),
+                    OneRegion(["chr1", start_b, end_b, "B"]),
+                ]
+            )
+
+            overlaps = regions.count_overlaps()
+            expected = max(0, min(end_a, end_b) - max(start_a, start_b))
+            self.assertEqual(overlaps.get(("A", "B"), 0), expected)
+            self.assertEqual(overlaps.get(("B", "A"), 0), expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,122 @@
+import hashlib
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from fp_tools import runtime
+
+
+class RuntimeManagerTest(unittest.TestCase):
+    def test_platform_keys_are_normalized(self):
+        with mock.patch("platform.system", return_value="Darwin"), mock.patch(
+            "platform.machine", return_value="arm64"
+        ):
+            self.assertEqual(runtime.platform_key(), "macos-arm64")
+        with mock.patch("platform.system", return_value="Linux"), mock.patch(
+            "platform.machine", return_value="aarch64"
+        ):
+            self.assertEqual(runtime.platform_key(), "linux-arm64")
+        with mock.patch("platform.system", return_value="Windows"), mock.patch(
+            "platform.machine", return_value="AMD64"
+        ):
+            self.assertEqual(runtime.platform_key(), "windows-x86_64")
+
+    def test_flag_path_translation_preserves_non_path_arguments(self):
+        translated = runtime.translate_flag_paths(
+            ["--samples", "reads.tsv", "--genome", "hg38", "--outdir=project", "--cores", "8"],
+            {"--samples", "--outdir"},
+            lambda value: "/mapped/" + value,
+        )
+        self.assertEqual(
+            translated,
+            ["--samples", "/mapped/reads.tsv", "--genome", "hg38", "--outdir=/mapped/project", "--cores", "8"],
+        )
+
+    def test_flag_path_translation_maps_every_value_of_a_list_option(self):
+        translated = runtime.translate_flag_paths(
+            ["--motifs", "a.meme", "b.meme", "--cores", "4"],
+            {"--motifs"},
+            lambda value: "/mapped/" + value,
+        )
+        self.assertEqual(
+            translated,
+            ["--motifs", "/mapped/a.meme", "/mapped/b.meme", "--cores", "4"],
+        )
+
+    def test_safe_extract_rejects_path_traversal(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive = Path(tmpdir) / "bad.tar.gz"
+            with tarfile.open(archive, "w:gz") as handle:
+                info = tarfile.TarInfo("../outside")
+                info.size = 1
+                handle.addfile(info, io.BytesIO(b"x"))
+            with self.assertRaises(runtime.RuntimeProvisionError):
+                runtime._safe_extract(archive, Path(tmpdir) / "extract")
+
+    def test_native_runtime_download_is_verified_and_cached(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            source = root / "runtime.tar.gz"
+            payload = root / "payload"
+            (payload / "bin").mkdir(parents=True)
+            for command in ("fastp", "samtools"):
+                path = payload / "bin" / command
+                path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                path.chmod(0o755)
+            with tarfile.open(source, "w:gz") as handle:
+                for path in sorted(payload.rglob("*")):
+                    handle.add(path, arcname=path.relative_to(payload))
+            digest = hashlib.sha256(source.read_bytes()).hexdigest()
+            manifest = {
+                "schema": 1,
+                "runtime_version": "test-1",
+                "repository": "example.invalid/runtime",
+                "components": {"core": {"commands": ["fastp", "samtools"]}},
+                "artifacts": {"linux-x86_64": {"core": {"tag": "test"}}},
+            }
+            with mock.patch.object(runtime, "load_runtime_manifest", return_value=manifest), mock.patch.object(
+                runtime, "runtime_cache_root", return_value=root / "cache"
+            ), mock.patch.object(runtime, "platform_key", return_value="linux-x86_64"), mock.patch.object(
+                runtime,
+                "_resolve_oci_layer",
+                return_value=(source.as_uri(), source.stat().st_size, digest),
+            ):
+                first = runtime.ensure_native_runtime("core")
+                second = runtime.ensure_native_runtime("core")
+            self.assertEqual(first.prefix, second.prefix)
+            self.assertTrue((first.prefix / "bin" / "fastp").is_file())
+            marker = json.loads((first.prefix / ".fp-tools-runtime.json").read_text())
+            self.assertEqual(marker["sha256"], digest)
+
+    def test_download_rejects_wrong_checksum(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source.tar.gz"
+            source.write_bytes(b"runtime")
+            destination = Path(tmpdir) / "download.tar.gz"
+            with self.assertRaises(runtime.RuntimeProvisionError):
+                runtime._download(source.as_uri(), destination, source.stat().st_size, "0" * 64)
+            self.assertFalse(destination.with_suffix(".gz.part").exists())
+
+    def test_runtime_status_does_not_download(self):
+        manifest = {
+            "runtime_version": "test-1",
+            "components": {"core": {"commands": []}},
+            "artifacts": {"linux-x86_64": {"core": {"tag": "test"}}},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.object(
+            runtime, "load_runtime_manifest", return_value=manifest
+        ), mock.patch.object(runtime, "runtime_cache_root", return_value=Path(tmpdir)), mock.patch.object(
+            runtime, "platform_key", return_value="linux-x86_64"
+        ), mock.patch.object(runtime, "_resolve_oci_layer") as resolver:
+            rows = runtime.runtime_status()
+        resolver.assert_not_called()
+        self.assertEqual(rows[0]["installed"], "no")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_wrappers.py
+++ b/tests/test_workflow_wrappers.py
@@ -1,12 +1,66 @@
+import contextlib
+import io
 import tempfile
 import unittest
 from pathlib import Path
 
-from fp_tools.tools.bulk_footprinting import _stage_complete, build_commands, build_parser, run_bulk_footprinting
+from fp_tools.tools.bulk_footprinting import (
+    _stage_complete,
+    build_commands,
+    build_parser,
+    build_prepare_command,
+    run_bulk_footprinting,
+)
 from fp_tools.tools.find_signature_fp import read_marker_sites_from_diff
 
 
 class WorkflowWrapperTest(unittest.TestCase):
+    def test_bulk_wrapper_accepts_raw_reads_as_alternative_input(self):
+        args = build_parser().parse_args(
+            [
+                "--reads-table", "reads.tsv",
+                "--comparison-table", "comparisons.tsv",
+                "--genome", "hg38",
+                "--outdir", "project",
+                "--cores", "8",
+            ]
+        )
+        command = build_prepare_command(args)
+        self.assertEqual(command[0], "prepare-atac")
+        self.assertEqual(command[command.index("--samples") + 1], "reads.tsv")
+        self.assertEqual(command[command.index("--runtime") + 1], "system")
+        self.assertIn("--profile", command)
+
+    def test_raw_read_dry_run_prints_the_complete_chain(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            comparisons = root / "comparisons.tsv"
+            comparisons.write_text(
+                "comparison\tcond1\tcond2\nA_vs_B\tA\tB\n", encoding="utf-8"
+            )
+            args = build_parser().parse_args(
+                [
+                    "--reads-table", str(root / "reads.tsv"),
+                    "--comparison-table", str(comparisons),
+                    "--genome", "hg38",
+                    "--outdir", str(root / "project"),
+                    "--dry-run",
+                ]
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(run_bulk_footprinting(args), 0)
+            text = output.getvalue()
+            for stage in (
+                "prepare-atac",
+                "atac-correct",
+                "call-footprints",
+                "match-motifs",
+                "diff-footprints",
+                "review-multi-comparisons",
+            ):
+                self.assertIn(f"[{stage}]", text)
+
     def test_bulk_wrapper_plans_complete_command_chain(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary
- fix all-zero differential statistics and one-base BED overlaps
- add first-use managed core/MEME/HOMER runtimes for Linux, macOS, and private Windows WSL2
- extend bulk-footprinting and the GUI from FASTQ/run accessions through interactive reports
- retain the complete multi-architecture container and add Windows/macOS desktop release packaging
- publish concise installation/runtime documentation for rc5

## Local validation
- full unittest suite passed
- strict MkDocs build and browser audit passed
- sdist/wheel build and twine checks passed
- fresh wheel: pip check and all 22 console command smoke tests passed

Closes #19
Closes #20