### PR TITLE
Use ORAS-native runtime registry authentication

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -64,15 +64,14 @@ jobs:
           ]
           assert not missing, f"Runtime is missing commands: {missing}"
           PY
-      - name: Log in to GHCR
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: oras-project/setup-oras@v1
         if: startsWith(github.ref, 'refs/tags/')
+      - name: Log in to GHCR with ORAS
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: printf '%s' "${GH_TOKEN}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
       - name: Publish runtime artifact
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
@@ -101,15 +100,14 @@ jobs:
           trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
           mkdir -p runtime-out
           docker export "${container_id}" | gzip -1 > runtime-out/fp-tools-wsl-rootfs.tar.gz
-      - name: Log in to GHCR
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: oras-project/setup-oras@v1
         if: startsWith(github.ref, 'refs/tags/')
+      - name: Log in to GHCR with ORAS
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: printf '%s' "${GH_TOKEN}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
       - name: Publish WSL2 runtime artifact
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash


### PR DESCRIPTION
## Summary
- authenticate runtime artifact publication directly with ORAS
- remove the Docker-dependent login action from native macOS runtime jobs
- preserve the same GHCR repository, tags, and release behavior

## Validation
- runtime archives and command validation passed on every target in PR #22
- this change addresses the tag-only macOS publish failure before any rc5 PyPI or GitHub release artifact was published