### PR TITLE
Fix release package visibility gates

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,6 +2,12 @@ name: Container
 
 on:
   workflow_dispatch:
+    inputs:
+      visibility_only:
+        description: Make the existing fp-tools container package public without rebuilding it
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - "v*"
@@ -23,6 +29,7 @@ env:
 
 jobs:
   image:
+    if: github.event_name != 'workflow_dispatch' || inputs.visibility_only != true
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
@@ -105,3 +112,16 @@ jobs:
             "${IMAGE}:${GITHUB_REF_NAME}-amd64" \
             "${IMAGE}:${GITHUB_REF_NAME}-arm64"
           docker buildx imagetools inspect "${IMAGE}:${GITHUB_REF_NAME}"
+
+  visibility:
+    name: public container package
+    if: always() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.visibility_only == true))
+    needs: [image, manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make the container package public
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools" \
+            -f visibility=public

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -118,7 +118,7 @@ jobs:
 
   publish-and-test:
     name: public artifact and Windows WSL2 smoke test
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     needs: [native, windows-wsl]
     runs-on: windows-latest
     timeout-minutes: 45
@@ -129,7 +129,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api --method PATCH "/orgs/oncologylab/packages/container/fp-tools-runtime" \
+          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools-runtime" \
             -f visibility=public
       - uses: actions/setup-python@v6
         with:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -93,7 +93,9 @@ macOS Intel and Linux users install the Python package instead.
 
 The `Container` workflow builds and tests the complete environment, then
 publishes `linux/amd64` and `linux/arm64` images to
-`ghcr.io/oncologylab/fp-tools` for tagged releases.
+`ghcr.io/oncologylab/fp-tools` for tagged releases. Its final job must confirm
+that the package is public; the `visibility_only` manual input can repair
+visibility without rebuilding images.
 
 The `Managed runtimes` workflow publishes pinned core, MEME, and HOMER archives
 for Linux and macOS, plus the private Windows WSL2 root filesystem. It must


### PR DESCRIPTION
Fix the final release visibility gates:

- prevent Git Bash from rewriting the runtime GitHub API endpoint as a local path
- allow a manual runtime dispatch to validate already-published artifacts
- make the multi-architecture container package public after tagged releases
- provide a visibility-only container repair that does not rebuild images

The rc5 runtime archives and container images themselves published successfully; the corrected gates make them anonymously installable and complete the Windows WSL2 consumer smoke.