### PR TITLE
Link release packages to the repository

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: boolean
         default: false
+      publish_version:
+        description: Existing package version to republish, for example 0.2.0rc5
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -49,7 +53,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GitHub Container Registry
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -83,17 +87,20 @@ jobs:
           docker logs fp-tools-gui-smoke
           exit 1
       - name: Push architecture image
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
         env:
           ARCH: ${{ matrix.arch }}
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
-          docker tag fp-tools:smoke "${IMAGE}:${GITHUB_REF_NAME}-${ARCH}"
-          docker push "${IMAGE}:${GITHUB_REF_NAME}-${ARCH}"
+          release_tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then release_tag="v${PUBLISH_VERSION#v}"; fi
+          docker tag fp-tools:smoke "${IMAGE}:${release_tag}-${ARCH}"
+          docker push "${IMAGE}:${release_tag}-${ARCH}"
 
   manifest:
     name: multi-architecture manifest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
     needs: image
     runs-on: ubuntu-latest
     steps:
@@ -105,17 +112,21 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish release and latest manifests
         shell: bash
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
+          release_tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then release_tag="v${PUBLISH_VERSION#v}"; fi
           docker buildx imagetools create \
-            --tag "${IMAGE}:${GITHUB_REF_NAME}" \
+            --tag "${IMAGE}:${release_tag}" \
             --tag "${IMAGE}:latest" \
-            "${IMAGE}:${GITHUB_REF_NAME}-amd64" \
-            "${IMAGE}:${GITHUB_REF_NAME}-arm64"
-          docker buildx imagetools inspect "${IMAGE}:${GITHUB_REF_NAME}"
+            "${IMAGE}:${release_tag}-amd64" \
+            "${IMAGE}:${release_tag}-arm64"
+          docker buildx imagetools inspect "${IMAGE}:${release_tag}"
 
   visibility:
     name: public container package
-    if: always() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.visibility_only == true))
+    if: always() && (startsWith(github.ref, 'refs/tags/') || inputs.publish_version != '' || (github.event_name == 'workflow_dispatch' && inputs.visibility_only == true))
     needs: [image, manifest]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -2,6 +2,11 @@ name: Managed runtimes
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_version:
+        description: Existing package version to republish, for example 0.2.0rc5
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -65,20 +70,24 @@ jobs:
           assert not missing, f"Runtime is missing commands: {missing}"
           PY
       - uses: oras-project/setup-oras@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
       - name: Log in to GHCR with ORAS
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: printf '%s' "${GH_TOKEN}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
       - name: Publish runtime artifact
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
           version="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then version="${PUBLISH_VERSION#v}"; fi
           tag="${{ matrix.component }}-${version}-${{ matrix.target.platform }}"
           oras push "${RUNTIME_REPOSITORY}:${tag}" \
+            --annotation "org.opencontainers.image.source=https://github.com/oncologylab/fp-tools" \
             "runtime-out/${{ matrix.component }}.tar.gz:application/gzip"
       - uses: actions/upload-artifact@v7
         with:
@@ -101,24 +110,28 @@ jobs:
           mkdir -p runtime-out
           docker export "${container_id}" | gzip -1 > runtime-out/fp-tools-wsl-rootfs.tar.gz
       - uses: oras-project/setup-oras@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
       - name: Log in to GHCR with ORAS
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: printf '%s' "${GH_TOKEN}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
       - name: Publish WSL2 runtime artifact
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
           version="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then version="${PUBLISH_VERSION#v}"; fi
           oras push "${RUNTIME_REPOSITORY}:wsl-core-${version}-linux-x86_64" \
+            --annotation "org.opencontainers.image.source=https://github.com/oncologylab/fp-tools" \
             "runtime-out/fp-tools-wsl-rootfs.tar.gz:application/gzip"
 
   publish-and-test:
     name: public artifact and Windows WSL2 smoke test
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
     needs: [native, windows-wsl]
     runs-on: windows-latest
     timeout-minutes: 45
@@ -140,6 +153,8 @@ jobs:
           python -m pip install --only-binary=:all: .
           fp-tools-runtime install core
           fp-tools-runtime status
+          $version = python -c "import fp_tools; print(fp_tools.__version__)"
+          $distroName = "fp-tools-" + ($version -replace '\.', '-')
           $distro = (wsl.exe --list --quiet | Out-String).Replace("`0", "")
-          if ($distro -notmatch "fp-tools-0-2-0rc5") { throw "fp-tools WSL runtime was not imported" }
-          wsl.exe --distribution fp-tools-0-2-0rc5 --exec /opt/conda/bin/prepare-atac --doctor --profile modern
+          if ($distro -notmatch [regex]::Escape($distroName)) { throw "fp-tools WSL runtime was not imported" }
+          wsl.exe --distribution $distroName --exec /opt/conda/bin/prepare-atac --doctor --profile modern

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mambaorg/micromamba:2.0.5
 
+LABEL org.opencontainers.image.source="https://github.com/oncologylab/fp-tools"
+
 WORKDIR /opt/fp-tools
 ENV FP_TOOLS_RUNTIME=system
 USER root

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -95,11 +95,14 @@ The `Container` workflow builds and tests the complete environment, then
 publishes `linux/amd64` and `linux/arm64` images to
 `ghcr.io/oncologylab/fp-tools` for tagged releases. Its final job must confirm
 that the package is public; the `visibility_only` manual input can repair
-visibility without rebuilding images.
+visibility without rebuilding images. The `publish_version` manual input
+rebuilds and republishes an existing version with repository-link metadata.
 
 The `Managed runtimes` workflow publishes pinned core, MEME, and HOMER archives
 for Linux and macOS, plus the private Windows WSL2 root filesystem. It must
 verify archive relocation and a real Windows WSL2 import before release handoff.
+Its `publish_version` manual input can rebuild and republish an existing version
+with repository-link metadata before repeating the public-consumer smoke test.
 
 The manual GitHub Actions `Publish` workflow uses the repository
 `PYPI_API_TOKEN` secret. Do not paste PyPI tokens into chat, shell history, or


### PR DESCRIPTION
Associate the fp-tools container and managed-runtime OCI packages with this repository before repeating the rc5 publication gates.

- add the official `org.opencontainers.image.source` metadata
- support an explicit `publish_version` repair without moving the release tag
- remove the hard-coded rc5 WSL distro name
- retain the visibility-only container repair path

This addresses the GitHub Packages 404 seen when an unlinked package was changed from private to public.