### PR TITLE
Prepare repository-linked rc6 release

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,7 @@ on:
         type: boolean
         default: false
       publish_version:
-        description: Existing package version to republish, for example 0.2.0rc5
+        description: Existing package version to republish, for example 0.2.0rc6
         required: false
         type: string
   push:
@@ -29,7 +29,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE: ghcr.io/oncologylab/fp-tools
+  IMAGE: ghcr.io/oncologylab/fp-tools-bio
 
 jobs:
   image:
@@ -134,5 +134,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools" \
+          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools-bio" \
             -f visibility=public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,30 +8,30 @@ permissions:
 
 jobs:
   wheels:
-    name: Wheels / ${{ matrix.os }}
+    name: Wheels / ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - {label: linux-x86_64, os: ubuntu-latest, archs: x86_64}
+          - {label: linux-arm64, os: ubuntu-24.04-arm, archs: aarch64}
+          - {label: macos, os: macos-latest, archs: "x86_64 arm64"}
+          - {label: windows-x64, os: windows-latest, archs: AMD64}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: docker/setup-qemu-action@v4
-        if: runner.os == 'Linux'
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v3.4.0
         env:
-          CIBW_ARCHS_LINUX: x86_64 aarch64
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS: ${{ matrix.archs }}
         with:
           output-dir: wheelhouse
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ runner.os }}
+          name: wheels-${{ matrix.label }}
           path: wheelhouse/*.whl
 
   sdist:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_version:
-        description: Existing package version to republish, for example 0.2.0rc5
+        description: Existing package version to republish, for example 0.2.0rc6
         required: false
         type: string
   push:
@@ -22,7 +22,7 @@ permissions:
   packages: write
 
 env:
-  RUNTIME_REPOSITORY: ghcr.io/oncologylab/fp-tools-runtime
+  RUNTIME_REPOSITORY: ghcr.io/oncologylab/fp-tools-bio-runtime
 
 jobs:
   native:
@@ -142,7 +142,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools-runtime" \
+          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools-bio-runtime" \
             -f visibility=public
       - uses: actions/setup-python@v6
         with:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc5
+version: 0.2.0rc6
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -45,9 +45,9 @@ a separately planned breaking release explicitly changes the contract.
   PyPI publication.
 - A complete amd64/arm64 container with the external genomics toolchain and a
   browser GUI as its default entry point.
-- Self-contained GUI executables for Windows x64, macOS Intel and Apple
-  Silicon, and Linux x64 and ARM64, with frozen-safe command and workflow
-  dispatch.
+- Self-contained GUI executables for Windows x64 and Apple Silicon, with
+  frozen-safe command and workflow dispatch. Linux and Intel macOS use the
+  Python package; the complete container remains available on amd64 and arm64.
 - Branded GitHub and MkDocs presentation with responsive embedded report and
   GUI demos plus automated desktop/mobile browser audits.
 - A manifest-pinned, storage-conscious ENCODE workflow for 17 biological
@@ -90,8 +90,9 @@ a separately planned breaking release explicitly changes the contract.
 8. Keep region-set examples outcome-independent: define groups from external
    annotations, match baseline signal before testing, report all motifs, and
    use explicit display motifs only to configure the initial browser view.
-9. Maintain binary-wheel and desktop-app scientific I/O parity on Windows,
-   macOS, and Linux. Test managed-runtime artifacts and keep the complete
+9. Maintain binary-wheel scientific I/O parity on Windows, macOS, and Linux,
+   plus desktop-app parity on Windows x64 and Apple Silicon. Test public,
+   repository-linked managed-runtime artifacts and keep the complete
    multi-architecture container as a reproducible alternative backend.
 
 ## Deferred or Experimental Work

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose one route:
 | --- | --- | --- |
 | Desktop app | Windows or Apple Silicon macOS | [Download](https://github.com/oncologylab/fp-tools/releases) |
 | Python package | Windows, macOS, or Linux with Python 3.11–3.13 | `python -m pip install fp-tools-bio` |
-| Container | Complete reproducible environment | `docker run --rm -p 8891:8891 ghcr.io/oncologylab/fp-tools:latest` |
+| Container | Complete reproducible environment | `docker run --rm -p 8891:8891 ghcr.io/oncologylab/fp-tools-bio:latest` |
 
 Python package example:
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -58,7 +58,8 @@ Primary current API checks:
 
 ## 4. Build Artifacts
 
-Release wheels are built by `cibuildwheel` in the manual `Publish` workflow.
+Release wheels are built by `cibuildwheel` in the manual `Publish` workflow;
+the two Linux architectures run as separate native jobs.
 The required artifact set is:
 
 - CPython 3.11, 3.12, and 3.13
@@ -93,7 +94,7 @@ macOS Intel and Linux users install the Python package instead.
 
 The `Container` workflow builds and tests the complete environment, then
 publishes `linux/amd64` and `linux/arm64` images to
-`ghcr.io/oncologylab/fp-tools` for tagged releases. Its final job must confirm
+`ghcr.io/oncologylab/fp-tools-bio` for tagged releases. Its final job must confirm
 that the package is public; the `visibility_only` manual input can repair
 visibility without rebuilding images. The `publish_version` manual input
 rebuilds and republishes an existing version with repository-link metadata.

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,7 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 | [`review-multi-comparisons`](#review-multi-comparisons) | Combine differential-footprint reports as a scalable browser bundle or one self-contained HTML report. |
 | [`run-yaml-workflow`](#run-yaml-workflow) | Run one or more fp-tools jobs from a reusable YAML configuration. |
 | [`fp-tools-gui`](#fp-tools-gui) | Launch the browser interface for configuring and running fp-tools commands. |
-| [`fp-tools-runtime`](#fp-tools-runtime) | Inspect, install, or repair the private external-tool runtime used by raw-read and de novo motif workflows. |
+| [`fp-tools-runtime`](#fp-tools-runtime) | Inspect, install, or repair the managed external-tool runtime used by raw-read and de novo motif workflows. |
 | [`discover-motifs`](#discover-motifs) | Prepare or run de novo motif discovery from candidate footprint intervals or an existing FASTA file. |
 | [`summarize-motifs`](#summarize-motifs) | Summarize MEME, STREME, DREME, and Tomtom results in a compact report. |
 | [`pseudobulk-fragments`](#pseudobulk-fragments) | Group single-cell ATAC fragments by a cell-annotation column to create pseudobulk inputs. |

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -31,19 +31,19 @@ automatically downloads the image when this one command starts the GUI.
 === "Windows PowerShell"
 
     ```powershell
-    docker run --rm -p 8891:8891 -v "${PWD}:/work" ghcr.io/oncologylab/fp-tools:latest
+    docker run --rm -p 8891:8891 -v "${PWD}:/work" ghcr.io/oncologylab/fp-tools-bio:latest
     ```
 
 === "macOS"
 
     ```bash
-    docker run --rm -p 8891:8891 -v "$PWD:/work" ghcr.io/oncologylab/fp-tools:latest
+    docker run --rm -p 8891:8891 -v "$PWD:/work" ghcr.io/oncologylab/fp-tools-bio:latest
     ```
 
 === "Linux"
 
     ```bash
-    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -p 8891:8891 -v "$PWD:/work" ghcr.io/oncologylab/fp-tools:latest
+    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -p 8891:8891 -v "$PWD:/work" ghcr.io/oncologylab/fp-tools-bio:latest
     ```
 
 Open `http://127.0.0.1:8891`. Files in the current directory appear under
@@ -51,7 +51,7 @@ Open `http://127.0.0.1:8891`. Files in the current directory appear under
 a command directly, for example:
 
 ```bash
-docker run --rm -v "$PWD:/work" ghcr.io/oncologylab/fp-tools:latest atac-correct --help
+docker run --rm -v "$PWD:/work" ghcr.io/oncologylab/fp-tools-bio:latest atac-correct --help
 ```
 
 ## Command-line package

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc5
+#      python -m pip install fp-tools-bio==0.2.0rc6
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc5}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc6}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc5</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc6</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc5"
+version = "0.2.0rc6"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -146,7 +146,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc5"
+version = "0.2.0rc6"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc5"
+__version__ = "0.2.0rc6"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc5",
-  "repository": "ghcr.io/oncologylab/fp-tools-runtime",
+  "runtime_version": "0.2.0rc6",
+  "repository": "ghcr.io/oncologylab/fp-tools-bio-runtime",
   "components": {
     "core": {
       "commands": [
@@ -37,29 +37,29 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"tag": "core-0.2.0rc5-linux-x86_64"},
-      "meme": {"tag": "meme-0.2.0rc5-linux-x86_64"},
-      "homer": {"tag": "homer-0.2.0rc5-linux-x86_64"}
+      "core": {"tag": "core-0.2.0rc6-linux-x86_64"},
+      "meme": {"tag": "meme-0.2.0rc6-linux-x86_64"},
+      "homer": {"tag": "homer-0.2.0rc6-linux-x86_64"}
     },
     "linux-arm64": {
-      "core": {"tag": "core-0.2.0rc5-linux-arm64"},
-      "meme": {"tag": "meme-0.2.0rc5-linux-arm64"},
-      "homer": {"tag": "homer-0.2.0rc5-linux-arm64"}
+      "core": {"tag": "core-0.2.0rc6-linux-arm64"},
+      "meme": {"tag": "meme-0.2.0rc6-linux-arm64"},
+      "homer": {"tag": "homer-0.2.0rc6-linux-arm64"}
     },
     "macos-x86_64": {
-      "core": {"tag": "core-0.2.0rc5-macos-x86_64"},
-      "meme": {"tag": "meme-0.2.0rc5-macos-x86_64"},
-      "homer": {"tag": "homer-0.2.0rc5-macos-x86_64"}
+      "core": {"tag": "core-0.2.0rc6-macos-x86_64"},
+      "meme": {"tag": "meme-0.2.0rc6-macos-x86_64"},
+      "homer": {"tag": "homer-0.2.0rc6-macos-x86_64"}
     },
     "macos-arm64": {
-      "core": {"tag": "core-0.2.0rc5-macos-arm64"},
-      "meme": {"tag": "meme-0.2.0rc5-macos-arm64"},
-      "homer": {"tag": "homer-0.2.0rc5-macos-arm64"}
+      "core": {"tag": "core-0.2.0rc6-macos-arm64"},
+      "meme": {"tag": "meme-0.2.0rc6-macos-arm64"},
+      "homer": {"tag": "homer-0.2.0rc6-macos-arm64"}
     },
     "windows-x86_64": {
-      "core": {"tag": "wsl-core-0.2.0rc5-linux-x86_64"},
-      "meme": {"tag": "wsl-core-0.2.0rc5-linux-x86_64"},
-      "homer": {"tag": "wsl-core-0.2.0rc5-linux-x86_64"}
+      "core": {"tag": "wsl-core-0.2.0rc6-linux-x86_64"},
+      "meme": {"tag": "wsl-core-0.2.0rc6-linux-x86_64"},
+      "homer": {"tag": "wsl-core-0.2.0rc6-linux-x86_64"}
     }
   }
 }

--- a/src/fp_tools/runtime.py
+++ b/src/fp_tools/runtime.py
@@ -533,7 +533,7 @@ def run_container_command(
         _replace_runtime_option(list(arguments), "system"), path_flags, translate
     )
     image = os.environ.get(
-        "FP_TOOLS_CONTAINER_IMAGE", f"ghcr.io/oncologylab/fp-tools:v{__version__}"
+        "FP_TOOLS_CONTAINER_IMAGE", f"ghcr.io/oncologylab/fp-tools-bio:v{__version__}"
     )
     invocation = [docker, "run", "--rm"]
     if os.name != "nt" and hasattr(os, "getuid"):

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import subprocess
 import sys
@@ -25,6 +26,15 @@ class ReleaseMetadataTest(unittest.TestCase):
         self.assertEqual(version, namespace["__version__"])
         citation = (ROOT / "CITATION.cff").read_text(encoding="utf-8")
         self.assertIn(f"version: {version}", citation)
+        runtime_manifest = json.loads(
+            (ROOT / "src/fp_tools/resources/runtime_manifest.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(version, runtime_manifest["runtime_version"])
+        self.assertEqual(
+            runtime_manifest["repository"], "ghcr.io/oncologylab/fp-tools-bio-runtime"
+        )
+        info_plist = (ROOT / "packaging/desktop/Info.plist").read_text(encoding="utf-8")
+        self.assertIn(f"<string>{version}</string>", info_plist)
         example = (ROOT / "examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh").read_text(encoding="utf-8")
         self.assertIn(f'VERSION="${{FP_TOOLS_VERSION:-{version}}}"', example)
 
@@ -93,9 +103,11 @@ class ReleaseMetadataTest(unittest.TestCase):
     def test_publish_workflow_uses_token_and_cross_platform_wheels(self):
         workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
         self.assertIn("pypa/cibuildwheel", workflow)
-        self.assertIn("CIBW_ARCHS_LINUX: x86_64 aarch64", workflow)
-        self.assertIn("CIBW_ARCHS_MACOS: x86_64 arm64", workflow)
-        self.assertIn("CIBW_ARCHS_WINDOWS: AMD64", workflow)
+        self.assertIn("os: ubuntu-latest, archs: x86_64", workflow)
+        self.assertIn("os: ubuntu-24.04-arm, archs: aarch64", workflow)
+        self.assertIn('os: macos-latest, archs: "x86_64 arm64"', workflow)
+        self.assertIn("os: windows-latest, archs: AMD64", workflow)
+        self.assertIn("CIBW_ARCHS: ${{ matrix.archs }}", workflow)
         self.assertIn("twine check", workflow)
         self.assertIn("twine upload", workflow)
         self.assertIn("TWINE_USERNAME: __token__", workflow)


### PR DESCRIPTION
Prepare the corrective rc6 release after GitHub confirmed that existing unlinked registry packages cannot be made public by the repository token.

- publish the complete image as `ghcr.io/oncologylab/fp-tools-bio`
- publish managed runtimes as `ghcr.io/oncologylab/fp-tools-bio-runtime`
- keep source metadata on first publication so both packages link to this repository
- bump every release/runtime/desktop version to 0.2.0rc6
- split Linux x86_64 and arm64 wheel builds onto native parallel runners
- update install docs and release-contract tests

Local validation: 382 tests passed (2 skipped), strict MkDocs and the browser audit passed, `pip check` passed in an isolated editable environment, and local wheel/sdist `twine check` passed.