### PR TITLE
Publish runtimes and containers as public release assets

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,13 +3,8 @@ name: Container
 on:
   workflow_dispatch:
     inputs:
-      visibility_only:
-        description: Make the existing fp-tools container package public without rebuilding it
-        required: false
-        type: boolean
-        default: false
       publish_version:
-        description: Existing package version to republish, for example 0.2.0rc6
+        description: Existing package version to rebuild, for example 0.2.0rc6
         required: false
         type: string
   push:
@@ -25,15 +20,10 @@ on:
       - .github/workflows/container.yml
 
 permissions:
-  contents: read
-  packages: write
-
-env:
-  IMAGE: ghcr.io/oncologylab/fp-tools-bio
+  contents: write
 
 jobs:
   image:
-    if: github.event_name != 'workflow_dispatch' || inputs.visibility_only != true
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
@@ -52,13 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
-      - name: Log in to GitHub Container Registry
-        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build native smoke image
         uses: docker/build-push-action@v7
         with:
@@ -86,7 +69,7 @@ jobs:
           done
           docker logs fp-tools-gui-smoke
           exit 1
-      - name: Push architecture image
+      - name: Pack architecture image
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
         env:
@@ -95,44 +78,46 @@ jobs:
         run: |
           release_tag="${GITHUB_REF_NAME}"
           if [[ "${GITHUB_REF}" != refs/tags/* ]]; then release_tag="v${PUBLISH_VERSION#v}"; fi
-          docker tag fp-tools:smoke "${IMAGE}:${release_tag}-${ARCH}"
-          docker push "${IMAGE}:${release_tag}-${ARCH}"
+          version="${release_tag#v}"
+          mkdir -p release
+          docker tag fp-tools:smoke "fp-tools:${release_tag}"
+          docker tag fp-tools:smoke fp-tools:latest
+          docker save "fp-tools:${release_tag}" fp-tools:latest | gzip -1 \
+            > "release/fp-tools-container-${version}-linux-${ARCH}.tar.gz"
+      - uses: actions/upload-artifact@v7
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
+        with:
+          name: fp-tools-container-${{ matrix.arch }}
+          path: release/fp-tools-container-*.tar.gz
+          if-no-files-found: error
 
-  manifest:
-    name: multi-architecture manifest
+  release:
+    name: container release archives
     if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
     needs: image
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      - uses: actions/download-artifact@v8
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish release and latest manifests
+          pattern: fp-tools-container-*
+          merge-multiple: true
+          path: release
+      - name: Upload container archives to the GitHub release
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
           release_tag="${GITHUB_REF_NAME}"
           if [[ "${GITHUB_REF}" != refs/tags/* ]]; then release_tag="v${PUBLISH_VERSION#v}"; fi
-          docker buildx imagetools create \
-            --tag "${IMAGE}:${release_tag}" \
-            --tag "${IMAGE}:latest" \
-            "${IMAGE}:${release_tag}-amd64" \
-            "${IMAGE}:${release_tag}-arm64"
-          docker buildx imagetools inspect "${IMAGE}:${release_tag}"
-
-  visibility:
-    name: public container package
-    if: always() && (startsWith(github.ref, 'refs/tags/') || inputs.publish_version != '' || (github.event_name == 'workflow_dispatch' && inputs.visibility_only == true))
-    needs: [image, manifest]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Make the container package public
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools-bio" \
-            -f visibility=public
+          (cd release && sha256sum fp-tools-container-*.tar.gz > CONTAINER_SHA256SUMS.txt)
+          if ! gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            release_flags=()
+            if [[ "${release_tag}" == *rc* ]]; then release_flags+=(--prerelease); fi
+            gh release create "${release_tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "fp-tools ${release_tag}" \
+              --generate-notes \
+              "${release_flags[@]}"
+          fi
+          gh release upload "${release_tag}" release/* --repo "${GITHUB_REPOSITORY}" --clobber

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -18,15 +18,34 @@ on:
       - .github/workflows/runtime.yml
 
 permissions:
-  contents: read
-  packages: write
-
-env:
-  RUNTIME_REPOSITORY: ghcr.io/oncologylab/fp-tools-bio-runtime
+  contents: write
 
 jobs:
+  ensure-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure the release exists
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
+        shell: bash
+        run: |
+          release_tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then release_tag="v${PUBLISH_VERSION#v}"; fi
+          if ! gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            release_flags=()
+            if [[ "${release_tag}" == *rc* ]]; then release_flags+=(--prerelease); fi
+            gh release create "${release_tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "fp-tools ${release_tag}" \
+              --generate-notes \
+              "${release_flags[@]}"
+          fi
+
   native:
     name: ${{ matrix.target.platform }} / ${{ matrix.component }}
+    needs: ensure-release
     runs-on: ${{ matrix.target.runner }}
     timeout-minutes: 120
     strategy:
@@ -69,26 +88,22 @@ jobs:
           ]
           assert not missing, f"Runtime is missing commands: {missing}"
           PY
-      - uses: oras-project/setup-oras@v1
-        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
-      - name: Log in to GHCR with ORAS
+      - name: Publish runtime archive
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: printf '%s' "${GH_TOKEN}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
-      - name: Publish runtime artifact
-        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
-        shell: bash
-        env:
           PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
           version="${GITHUB_REF_NAME#v}"
           if [[ "${GITHUB_REF}" != refs/tags/* ]]; then version="${PUBLISH_VERSION#v}"; fi
-          tag="${{ matrix.component }}-${version}-${{ matrix.target.platform }}"
-          oras push "${RUNTIME_REPOSITORY}:${tag}" \
-            --annotation "org.opencontainers.image.source=https://github.com/oncologylab/fp-tools" \
-            "runtime-out/${{ matrix.component }}.tar.gz:application/gzip"
+          release_tag="v${version}"
+          asset="fp-tools-runtime-${{ matrix.component }}-${version}-${{ matrix.target.platform }}.tar.gz"
+          mv "runtime-out/${{ matrix.component }}.tar.gz" "runtime-out/${asset}"
+          (cd runtime-out && sha256sum "${asset}" > "${asset}.sha256")
+          gh release upload "${release_tag}" \
+            "runtime-out/${asset}" "runtime-out/${asset}.sha256" \
+            --repo "${GITHUB_REPOSITORY}" --clobber
       - uses: actions/upload-artifact@v7
         with:
           name: runtime-${{ matrix.target.platform }}-${{ matrix.component }}-metadata
@@ -96,6 +111,7 @@ jobs:
 
   windows-wsl:
     name: windows-x64 / private WSL2 runtime
+    needs: ensure-release
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -109,25 +125,22 @@ jobs:
           trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
           mkdir -p runtime-out
           docker export "${container_id}" | gzip -1 > runtime-out/fp-tools-wsl-rootfs.tar.gz
-      - uses: oras-project/setup-oras@v1
-        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
-      - name: Log in to GHCR with ORAS
+      - name: Publish WSL2 runtime archive
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: printf '%s' "${GH_TOKEN}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
-      - name: Publish WSL2 runtime artifact
-        if: startsWith(github.ref, 'refs/tags/') || inputs.publish_version != ''
-        shell: bash
-        env:
           PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
           version="${GITHUB_REF_NAME#v}"
           if [[ "${GITHUB_REF}" != refs/tags/* ]]; then version="${PUBLISH_VERSION#v}"; fi
-          oras push "${RUNTIME_REPOSITORY}:wsl-core-${version}-linux-x86_64" \
-            --annotation "org.opencontainers.image.source=https://github.com/oncologylab/fp-tools" \
-            "runtime-out/fp-tools-wsl-rootfs.tar.gz:application/gzip"
+          release_tag="v${version}"
+          asset="fp-tools-runtime-wsl-core-${version}-linux-x86_64.tar.gz"
+          mv runtime-out/fp-tools-wsl-rootfs.tar.gz "runtime-out/${asset}"
+          (cd runtime-out && sha256sum "${asset}" > "${asset}.sha256")
+          gh release upload "${release_tag}" \
+            "runtime-out/${asset}" "runtime-out/${asset}.sha256" \
+            --repo "${GITHUB_REPOSITORY}" --clobber
 
   publish-and-test:
     name: public artifact and Windows WSL2 smoke test
@@ -137,13 +150,6 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - name: Make the runtime repository public
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api --method PATCH "orgs/oncologylab/packages/container/fp-tools-bio-runtime" \
-            -f visibility=public
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose one route:
 | --- | --- | --- |
 | Desktop app | Windows or Apple Silicon macOS | [Download](https://github.com/oncologylab/fp-tools/releases) |
 | Python package | Windows, macOS, or Linux with Python 3.11–3.13 | `python -m pip install fp-tools-bio` |
-| Container | Complete reproducible environment | `docker run --rm -p 8891:8891 ghcr.io/oncologylab/fp-tools-bio:latest` |
+| Container | Complete reproducible environment | `docker build -t fp-tools:latest https://github.com/oncologylab/fp-tools.git#main` |
 
 Python package example:
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -92,18 +92,16 @@ bundled Streamlit application starts, and its command check verifies frozen
 child-process dispatch. Release assets include a SHA-256 checksum manifest.
 macOS Intel and Linux users install the Python package instead.
 
-The `Container` workflow builds and tests the complete environment, then
-publishes `linux/amd64` and `linux/arm64` images to
-`ghcr.io/oncologylab/fp-tools-bio` for tagged releases. Its final job must confirm
-that the package is public; the `visibility_only` manual input can repair
-visibility without rebuilding images. The `publish_version` manual input
-rebuilds and republishes an existing version with repository-link metadata.
+The `Container` workflow builds and tests the complete environment on
+`linux/amd64` and `linux/arm64`, then attaches both loadable image archives and
+their checksums to tagged GitHub releases. The `publish_version` manual input
+can rebuild archives for an existing version.
 
-The `Managed runtimes` workflow publishes pinned core, MEME, and HOMER archives
-for Linux and macOS, plus the private Windows WSL2 root filesystem. It must
-verify archive relocation and a real Windows WSL2 import before release handoff.
-Its `publish_version` manual input can rebuild and republish an existing version
-with repository-link metadata before repeating the public-consumer smoke test.
+The `Managed runtimes` workflow attaches pinned core, MEME, and HOMER archives
+for Linux and macOS, plus the private Windows WSL2 root filesystem, to the
+public GitHub release with SHA-256 sidecars. It must verify archive relocation
+and a real Windows WSL2 import before release handoff. Its `publish_version`
+manual input can rebuild archives before repeating the public-consumer smoke.
 
 The manual GitHub Actions `Publish` workflow uses the repository
 `PYPI_API_TOKEN` secret. Do not paste PyPI tokens into chat, shell history, or

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -25,25 +25,29 @@ with permission if needed, and Windows may request one restart.
 
 ## Complete container
 
-The container includes fp-tools and its external genomics programs. Docker
-automatically downloads the image when this one command starts the GUI.
+The container includes fp-tools and its external genomics programs. Build it
+once, or load the matching prebuilt archive from the GitHub release:
+
+```bash
+docker build -t fp-tools:latest https://github.com/oncologylab/fp-tools.git#main
+```
 
 === "Windows PowerShell"
 
     ```powershell
-    docker run --rm -p 8891:8891 -v "${PWD}:/work" ghcr.io/oncologylab/fp-tools-bio:latest
+    docker run --rm -p 8891:8891 -v "${PWD}:/work" fp-tools:latest
     ```
 
 === "macOS"
 
     ```bash
-    docker run --rm -p 8891:8891 -v "$PWD:/work" ghcr.io/oncologylab/fp-tools-bio:latest
+    docker run --rm -p 8891:8891 -v "$PWD:/work" fp-tools:latest
     ```
 
 === "Linux"
 
     ```bash
-    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -p 8891:8891 -v "$PWD:/work" ghcr.io/oncologylab/fp-tools-bio:latest
+    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -p 8891:8891 -v "$PWD:/work" fp-tools:latest
     ```
 
 Open `http://127.0.0.1:8891`. Files in the current directory appear under
@@ -51,7 +55,7 @@ Open `http://127.0.0.1:8891`. Files in the current directory appear under
 a command directly, for example:
 
 ```bash
-docker run --rm -v "$PWD:/work" ghcr.io/oncologylab/fp-tools-bio:latest atac-correct --help
+docker run --rm -v "$PWD:/work" fp-tools:latest atac-correct --help
 ```
 
 ## Command-line package

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
   "runtime_version": "0.2.0rc6",
-  "repository": "ghcr.io/oncologylab/fp-tools-bio-runtime",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc6",
   "components": {
     "core": {
       "commands": [
@@ -37,29 +37,29 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"tag": "core-0.2.0rc6-linux-x86_64"},
-      "meme": {"tag": "meme-0.2.0rc6-linux-x86_64"},
-      "homer": {"tag": "homer-0.2.0rc6-linux-x86_64"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"tag": "core-0.2.0rc6-linux-arm64"},
-      "meme": {"tag": "meme-0.2.0rc6-linux-arm64"},
-      "homer": {"tag": "homer-0.2.0rc6-linux-arm64"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "core": {"tag": "core-0.2.0rc6-macos-x86_64"},
-      "meme": {"tag": "meme-0.2.0rc6-macos-x86_64"},
-      "homer": {"tag": "homer-0.2.0rc6-macos-x86_64"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-macos-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-macos-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "core": {"tag": "core-0.2.0rc6-macos-arm64"},
-      "meme": {"tag": "meme-0.2.0rc6-macos-arm64"},
-      "homer": {"tag": "homer-0.2.0rc6-macos-arm64"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-macos-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-macos-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "core": {"tag": "wsl-core-0.2.0rc6-linux-x86_64"},
-      "meme": {"tag": "wsl-core-0.2.0rc6-linux-x86_64"},
-      "homer": {"tag": "wsl-core-0.2.0rc6-linux-x86_64"}
+      "core": {"filename": "fp-tools-runtime-wsl-core-0.2.0rc6-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-wsl-core-0.2.0rc6-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-wsl-core-0.2.0rc6-linux-x86_64.tar.gz"}
     }
   }
 }

--- a/src/fp_tools/runtime.py
+++ b/src/fp_tools/runtime.py
@@ -116,19 +116,28 @@ def _runtime_spec(component: str, target_platform: str | None = None) -> dict:
         raise RuntimeProvisionError(
             f"Managed runtime component {component!r} is not available for {target}."
         ) from exc
-    return {
+    spec = {
         "schema": manifest["schema"],
         "runtime_version": manifest["runtime_version"],
-        "repository": manifest["repository"],
         "commands": manifest["components"][component]["commands"],
         **artifact,
     }
+    for key in ("repository", "release_base_url"):
+        if key in manifest:
+            spec[key] = manifest[key]
+    return spec
 
 
 def _request_json(url: str, headers: dict[str, str] | None = None) -> tuple[dict, dict]:
     request = urllib.request.Request(url, headers=headers or {})
     with urllib.request.urlopen(request, timeout=60) as response:
         return json.load(response), dict(response.headers)
+
+
+def _request_text(url: str) -> str:
+    request = urllib.request.Request(url)
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read().decode("utf-8")
 
 
 def _oci_bearer_token(repository: str) -> str:
@@ -163,6 +172,18 @@ def _resolve_oci_layer(repository: str, tag: str) -> tuple[str, int, str]:
     size = int(layer.get("size", 0))
     url = f"https://{registry}/v2/{image}/blobs/{digest}"
     return url, size, digest.split(":", 1)[1]
+
+
+def _resolve_runtime_artifact(spec: dict) -> tuple[str, int, str]:
+    filename = spec.get("filename")
+    release_base_url = spec.get("release_base_url")
+    if filename and release_base_url:
+        url = f"{str(release_base_url).rstrip('/')}/{urllib.parse.quote(str(filename))}"
+        checksum = _request_text(url + ".sha256").strip().split()[0].lower()
+        if len(checksum) != 64 or any(char not in "0123456789abcdef" for char in checksum):
+            raise RuntimeProvisionError(f"Runtime artifact {filename} has no valid SHA-256 checksum.")
+        return url, 0, checksum
+    return _resolve_oci_layer(spec["repository"], spec["tag"])
 
 
 def _download(url: str, destination: Path, expected_size: int, expected_sha256: str) -> None:
@@ -282,7 +303,7 @@ def ensure_native_runtime(component: str = "core") -> RuntimeActivation:
     with _install_lock(root / f".{component}.lock"):
         if ready.is_file():
             return RuntimeActivation("managed", component, prefix=prefix)
-        url, size, digest = _resolve_oci_layer(spec["repository"], spec["tag"])
+        url, size, digest = _resolve_runtime_artifact(spec)
         _free_space_check(root, size)
         archive = root / f"{component}.tar.gz"
         _download(url, archive, size, digest)
@@ -383,7 +404,7 @@ def ensure_wsl_runtime(component: str = "core") -> RuntimeActivation:
     with _install_lock(root / ".wsl.lock"):
         if distro in _wsl_distributions():
             return RuntimeActivation("managed", component, distro=distro)
-        url, size, digest = _resolve_oci_layer(spec["repository"], spec["tag"])
+        url, size, digest = _resolve_runtime_artifact(spec)
         _free_space_check(root, size)
         archive = root / "fp-tools-wsl-rootfs.tar.gz"
         _download(url, archive, size, digest)
@@ -533,7 +554,7 @@ def run_container_command(
         _replace_runtime_option(list(arguments), "system"), path_flags, translate
     )
     image = os.environ.get(
-        "FP_TOOLS_CONTAINER_IMAGE", f"ghcr.io/oncologylab/fp-tools-bio:v{__version__}"
+        "FP_TOOLS_CONTAINER_IMAGE", f"fp-tools:v{__version__}"
     )
     invocation = [docker, "run", "--rm"]
     if os.name != "nt" and hasattr(os, "getuid"):

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -31,7 +31,8 @@ class ReleaseMetadataTest(unittest.TestCase):
         )
         self.assertEqual(version, runtime_manifest["runtime_version"])
         self.assertEqual(
-            runtime_manifest["repository"], "ghcr.io/oncologylab/fp-tools-bio-runtime"
+            runtime_manifest["release_base_url"],
+            f"https://github.com/oncologylab/fp-tools/releases/download/v{version}",
         )
         info_plist = (ROOT / "packaging/desktop/Info.plist").read_text(encoding="utf-8")
         self.assertIn(f"<string>{version}</string>", info_plist)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -83,7 +83,7 @@ class RuntimeManagerTest(unittest.TestCase):
                 runtime, "runtime_cache_root", return_value=root / "cache"
             ), mock.patch.object(runtime, "platform_key", return_value="linux-x86_64"), mock.patch.object(
                 runtime,
-                "_resolve_oci_layer",
+                "_resolve_runtime_artifact",
                 return_value=(source.as_uri(), source.stat().st_size, digest),
             ):
                 first = runtime.ensure_native_runtime("core")
@@ -92,6 +92,25 @@ class RuntimeManagerTest(unittest.TestCase):
             self.assertTrue((first.prefix / "bin" / "fastp").is_file())
             marker = json.loads((first.prefix / ".fp-tools-runtime.json").read_text())
             self.assertEqual(marker["sha256"], digest)
+
+    def test_release_artifact_uses_public_checksum_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            archive = root / "runtime.tar.gz"
+            archive.write_bytes(b"runtime")
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            (root / "runtime.tar.gz.sha256").write_text(
+                f"{digest}  runtime.tar.gz\n", encoding="utf-8"
+            )
+            url, size, observed = runtime._resolve_runtime_artifact(
+                {
+                    "release_base_url": root.as_uri(),
+                    "filename": "runtime.tar.gz",
+                }
+            )
+        self.assertEqual(url, archive.as_uri())
+        self.assertEqual(size, 0)
+        self.assertEqual(observed, digest)
 
     def test_download_rejects_wrong_checksum(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Remove the dependency on organization-level GHCR visibility settings.

- publish managed Linux/macOS/WSL2 runtimes as public GitHub release assets with SHA-256 sidecars
- resolve, resume, verify, and install those assets directly from the package
- publish tested amd64/arm64 Docker image archives on the same release
- retain one-command Docker source builds and the explicit container backend
- preserve the real Windows WSL2 import smoke test

Validation: 383 tests passed (2 skipped), strict MkDocs passed, browser audit passed, and focused runtime/release tests passed in an isolated editable environment.