### PR TITLE
Make desktop and GUI workflows BAM-first

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_version:
-        description: Existing package version to rebuild, for example 0.2.0rc6
+        description: Existing package version to rebuild, for example 0.2.0rc7
         required: false
         type: string
   push:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - packaging/desktop/**
+      - scripts/audit_desktop_gui.py
       - scripts/smoke_desktop_bundle.py
       - pyproject.toml
       - src/**
@@ -39,12 +40,20 @@ jobs:
       - name: Install fp-tools and bundler
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --only-binary=:all: . "pyinstaller>=6.19,<7"
+          python -m pip install --only-binary=:all: . "pyinstaller>=6.19,<7" "playwright>=1.55,<2"
+          python -m playwright install chromium
           python -m pip check
       - name: Build one-file desktop executable
         run: pyinstaller --clean --noconfirm packaging/desktop/fp-tools-gui.spec
       - name: Smoke-test command dispatch and GUI startup
         run: python scripts/smoke_desktop_bundle.py "${{ matrix.executable }}"
+      - name: Audit responsive desktop GUI
+        run: python scripts/audit_desktop_gui.py "${{ matrix.executable }}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: desktop-audit-${{ matrix.label }}
+          path: desktop-gui-audit/*.png
+          if-no-files-found: error
       - name: Name release asset
         if: runner.os == 'Windows'
         shell: python

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_version:
-        description: Existing package version to republish, for example 0.2.0rc6
+        description: Existing package version to republish, for example 0.2.0rc7
         required: false
         type: string
   push:
@@ -44,19 +44,22 @@ jobs:
           fi
 
   native:
-    name: ${{ matrix.target.platform }} / ${{ matrix.component }}
+    name: ${{ matrix.platform }} / ${{ matrix.component }}
     needs: ensure-release
-    runs-on: ${{ matrix.target.runner }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        component: [core, meme, homer]
-        target:
-          - {runner: ubuntu-latest, platform: linux-x86_64}
-          - {runner: ubuntu-24.04-arm, platform: linux-arm64}
-          - {runner: macos-15-intel, platform: macos-x86_64}
-          - {runner: macos-15, platform: macos-arm64}
+        include:
+          - {runner: ubuntu-latest, platform: linux-x86_64, component: core}
+          - {runner: ubuntu-latest, platform: linux-x86_64, component: meme}
+          - {runner: ubuntu-latest, platform: linux-x86_64, component: homer}
+          - {runner: ubuntu-24.04-arm, platform: linux-arm64, component: core}
+          - {runner: ubuntu-24.04-arm, platform: linux-arm64, component: meme}
+          - {runner: ubuntu-24.04-arm, platform: linux-arm64, component: homer}
+          - {runner: macos-15-intel, platform: macos-x86_64, component: meme}
+          - {runner: macos-15, platform: macos-arm64, component: meme}
     steps:
       - uses: actions/checkout@v7
       - uses: mamba-org/setup-micromamba@v2
@@ -98,7 +101,7 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           if [[ "${GITHUB_REF}" != refs/tags/* ]]; then version="${PUBLISH_VERSION#v}"; fi
           release_tag="v${version}"
-          asset="fp-tools-runtime-${{ matrix.component }}-${version}-${{ matrix.target.platform }}.tar.gz"
+          asset="fp-tools-runtime-${{ matrix.component }}-${version}-${{ matrix.platform }}.tar.gz"
           mv "runtime-out/${{ matrix.component }}.tar.gz" "runtime-out/${asset}"
           (cd runtime-out && sha256sum "${asset}" > "${asset}.sha256")
           gh release upload "${release_tag}" \
@@ -106,22 +109,24 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" --clobber
       - uses: actions/upload-artifact@v7
         with:
-          name: runtime-${{ matrix.target.platform }}-${{ matrix.component }}-metadata
+          name: runtime-${{ matrix.platform }}-${{ matrix.component }}-metadata
           path: runtime-out/${{ matrix.component }}-sbom.json
 
   windows-wsl:
-    name: windows-x64 / private WSL2 runtime
+    name: windows-x64 / MEME WSL2 runtime
     needs: ensure-release
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
-      - name: Build and export complete runtime rootfs
+      - name: Build and export MEME-only runtime rootfs
         shell: bash
         run: |
-          docker build -t fp-tools-wsl-runtime .
-          container_id="$(docker create fp-tools-wsl-runtime)"
+          docker build \
+            -f packaging/runtime/windows-meme.Dockerfile \
+            -t fp-tools-wsl-meme-runtime .
+          container_id="$(docker create fp-tools-wsl-meme-runtime)"
           trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
           mkdir -p runtime-out
           docker export "${container_id}" | gzip -1 > runtime-out/fp-tools-wsl-rootfs.tar.gz
@@ -135,7 +140,7 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           if [[ "${GITHUB_REF}" != refs/tags/* ]]; then version="${PUBLISH_VERSION#v}"; fi
           release_tag="v${version}"
-          asset="fp-tools-runtime-wsl-core-${version}-linux-x86_64.tar.gz"
+          asset="fp-tools-runtime-wsl-meme-${version}-linux-x86_64.tar.gz"
           mv runtime-out/fp-tools-wsl-rootfs.tar.gz "runtime-out/${asset}"
           (cd runtime-out && sha256sum "${asset}" > "${asset}.sha256")
           gh release upload "${release_tag}" \
@@ -157,10 +162,10 @@ jobs:
         shell: pwsh
         run: |
           python -m pip install --only-binary=:all: .
-          fp-tools-runtime install core
+          fp-tools-runtime install meme
           fp-tools-runtime status
           $version = python -c "import fp_tools; print(fp_tools.__version__)"
           $distroName = "fp-tools-" + ($version -replace '\.', '-')
           $distro = (wsl.exe --list --quiet | Out-String).Replace("`0", "")
           if ($distro -notmatch [regex]::Escape($distroName)) { throw "fp-tools WSL runtime was not imported" }
-          wsl.exe --distribution $distroName --exec /opt/conda/bin/prepare-atac --doctor --profile modern
+          wsl.exe --distribution $distroName --exec /opt/conda/bin/streme --version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ unless the user explicitly asks to publish the manuscript source.
 - Direct CLI remains primary. YAML configs and the GUI are wrapper paths, not
   replacements for direct command use.
 - GUI-saved YAML must remain runnable with `run-yaml-workflow`.
+- Every GUI and the Windows/macOS desktop applications start bulk workflows
+  from coordinate-sorted BAM/BAI and matching peak BED files. Do not expose
+  FASTQ-to-BAM preparation through GUI forms, GUI YAML, or desktop dispatch.
+- `prepare-atac` and `bulk-footprinting --reads-table` are supported only by
+  the Linux CLI and Linux container. Native macOS/Windows commands must reject
+  raw-read mode before downloads, filesystem writes, or runtime setup.
 - Use the current public command names in docs and examples:
   `prepare-atac`, `bulk-footprinting`, `atac-correct`, `call-footprints`,
   `match-motifs`, `diff-footprints`, `normalize-bigwig`, `plot-aggregate`,
@@ -28,9 +34,9 @@ unless the user explicitly asks to publish the manuscript source.
   `find-signature-fp`, and `sc-footprinting`.
 - Do not reintroduce the removed TOBIAS-style console aliases. Use the current
   command names above in code, tests, docs, and examples.
-- Keep external genomics programs behind the runtime abstraction. Raw-read and
-  executable motif workflows default to the pinned managed runtime; `system`
-  and `container` remain explicit alternative backends.
+- Keep external genomics programs behind the runtime abstraction. Linux
+  raw-read and cross-platform executable motif workflows default to the pinned
+  managed runtime; `system` and `container` remain explicit alternatives.
 
 ## Common Development Commands
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc6
+version: 0.2.0rc7
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -20,12 +20,15 @@ a separately planned breaking release explicitly changes the contract.
 
 ## Completed Capabilities
 
-- Raw-read ATAC preparation with modern and legacy processing profiles.
+- Linux CLI/container raw-read ATAC preparation with modern and legacy
+  processing profiles.
 - A managed, versioned external-tool runtime downloaded on first use, with
-  native Linux/macOS archives, a private WSL2 runtime for Windows, and the
-  complete container retained as an explicit backend.
-- One-command bulk analysis from FASTQ files or public run accessions through
-  portable multi-comparison HTML reports.
+  Linux raw-read components, cross-platform optional MEME components, and the
+  complete Linux container retained as an explicit backend.
+- Cross-platform one-command bulk analysis from coordinate-sorted BAM/BAI and
+  matching peak BED files through portable multi-comparison HTML reports.
+- Optional Linux CLI/container bulk analysis from FASTQ files or public run
+  accessions through the same downstream workflow.
 - Tn5 bias correction, background scaling, footprint scoring, candidate calls,
   known-motif matching, de novo motif preparation, and aggregate plotting.
 - Replicate-aware differential footprint reports, including per-sample motif
@@ -47,9 +50,10 @@ a separately planned breaking release explicitly changes the contract.
   PyPI publication.
 - A complete amd64/arm64 container with the external genomics toolchain and a
   browser GUI as its default entry point.
-- Self-contained GUI executables for Windows x64 and Apple Silicon, with
-  frozen-safe command and workflow dispatch. Linux and Intel macOS use the
-  Python package; the complete container remains available on amd64 and arm64.
+- BAM-first self-contained GUI executables for Windows x64 and Apple Silicon,
+  with frozen-safe command and workflow dispatch. Every GUI starts from BAM/BAI
+  plus peak BED files. Linux and Intel macOS use the Python package; the
+  complete container remains available on amd64 and arm64.
 - Branded GitHub and MkDocs presentation with responsive embedded report and
   GUI demos plus automated desktop/mobile browser audits.
 - A manifest-pinned, storage-conscious ENCODE workflow for 17 biological
@@ -92,10 +96,10 @@ a separately planned breaking release explicitly changes the contract.
 8. Keep region-set examples outcome-independent: define groups from external
    annotations, match baseline signal before testing, report all motifs, and
    use explicit display motifs only to configure the initial browser view.
-9. Maintain binary-wheel scientific I/O parity on Windows, macOS, and Linux,
-   plus desktop-app parity on Windows x64 and Apple Silicon. Test public,
-   repository-linked managed-runtime artifacts and keep the complete
-   multi-architecture container as a reproducible alternative backend.
+9. Maintain BAM/peak scientific I/O parity on Windows, macOS, and Linux, plus
+   desktop-app parity on Windows x64 and Apple Silicon. Test Linux raw-read and
+   cross-platform MEME runtime artifacts separately, and keep the complete
+   multi-architecture Linux container as a reproducible alternative backend.
 
 ## Deferred or Experimental Work
 
@@ -119,5 +123,5 @@ instructions belong only in `RELEASE_CHECKLIST.md`.
 
 The GUI remains a thin wrapper included in the standard installation. Future
 GUI changes must keep direct CLI use primary, retain reusable YAML, avoid
-hosted-service assumptions, and use the current static demo and layout as the
-visual baseline.
+hosted-service assumptions, enforce the BAM/BAI plus peak BED starting point,
+and use the current static demo and layout as the visual baseline.

--- a/README.md
+++ b/README.md
@@ -40,20 +40,19 @@ python -m pip install --pre fp-tools-bio
 fp-tools-gui
 ```
 
-External genomics programs are downloaded into a private, versioned cache on
-first use. They do not need to be installed separately. Docker remains an
-optional reproducible backend.
+Optional de novo motif tools are downloaded into a private, versioned cache on
+first use. Docker remains an optional reproducible backend.
 
 ## Bulk ATAC-seq
 
-`bulk-footprinting` can run from FASTQ files or public run accessions through
-the final interactive comparison report.
+`bulk-footprinting` runs from coordinate-sorted BAM/BAI files and matching peak
+BED files through the final interactive comparison report.
 
 ```bash
 bulk-footprinting \
-  --reads-table reads.tsv \
+  --sample-table samples.tsv \
   --comparison-table comparisons.tsv \
-  --genome hg38 \
+  --genome hg38.fa.gz \
   --outdir project \
   --cores 8
 ```
@@ -62,6 +61,10 @@ The wrapper runs `atac-correct`, `call-footprints`, `match-motifs`,
 `diff-footprints`, and `review-multi-comparisons`. Each command can also be run
 directly. `diff-footprints --comparison-axis regions` compares matched genomic
 region sets within one sample or across biological replicates.
+
+FASTQ-to-BAM preparation is available through `prepare-atac` on the Linux CLI
+and in the Linux container. The GUI and native macOS/Windows installations
+start from BAM/BAI and peak BED files.
 
 ## Single-cell ATAC-seq
 
@@ -84,7 +87,8 @@ sc-footprinting \
 
 | Area | Commands |
 | --- | --- |
-| Core analysis | `prepare-atac`, `atac-correct`, `call-footprints`, `match-motifs`, `diff-footprints`, `normalize-bigwig` |
+| Core analysis | `atac-correct`, `call-footprints`, `match-motifs`, `diff-footprints`, `normalize-bigwig` |
+| Linux preprocessing | `prepare-atac` |
 | Workflows | `bulk-footprinting`, `sc-footprinting`, `run-yaml-workflow`, `fp-tools-gui`, `fp-tools-runtime` |
 | Reports | `plot-aggregate`, `review-multi-comparisons` |
 | De novo motifs | `discover-motifs`, `summarize-motifs` |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -56,6 +56,17 @@ Primary current API checks:
 .venv/bin/run-yaml-workflow --config examples/gui_configs/call_footprints_single.yml --dry-run
 ```
 
+Platform contract checks:
+
+- Linux CLI and the Linux container support `prepare-atac` and
+  `bulk-footprinting --reads-table`.
+- Native macOS and Windows commands reject raw-read mode before downloads or
+  output creation while keeping `prepare-atac --help` available.
+- Every GUI and both desktop bundles accept BAM/BAI plus peak BED inputs and
+  reject `prepare-atac`, `reads_table`, and equivalent extra arguments.
+- Non-Linux runtime manifests expose the optional MEME component only; Linux
+  manifests also expose raw-read core and HOMER components.
+
 ## 4. Build Artifacts
 
 Release wheels are built by `cibuildwheel` in the manual `Publish` workflow;
@@ -98,10 +109,11 @@ their checksums to tagged GitHub releases. The `publish_version` manual input
 can rebuild archives for an existing version.
 
 The `Managed runtimes` workflow attaches pinned core, MEME, and HOMER archives
-for Linux and macOS, plus the private Windows WSL2 root filesystem, to the
-public GitHub release with SHA-256 sidecars. It must verify archive relocation
-and a real Windows WSL2 import before release handoff. Its `publish_version`
-manual input can rebuild archives before repeating the public-consumer smoke.
+for Linux, MEME archives for macOS, and the private Windows MEME WSL2 runtime to
+the public GitHub release with SHA-256 sidecars. It must verify archive
+relocation and a real Windows WSL2 import before release handoff. Its
+`publish_version` manual input can rebuild archives before repeating the
+public-consumer smoke.
 
 The manual GitHub Actions `Publish` workflow uses the repository
 `PYPI_API_TOKEN` secret. Do not paste PyPI tokens into chat, shell history, or

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,8 +9,8 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 
 | Command | Purpose |
 | --- | --- |
-| [`prepare-atac`](#prepare-atac) | Download public ATAC-seq reads or use local FASTQ files, then trim, align, filter, call peaks, calculate alignment coverage, and write QC files. Use this command when the analysis starts from reads; skip it when filtered BAM and peak files already exist. The default runtime downloads its pinned external tools on first use. |
-| [`bulk-footprinting`](#bulk-footprinting) | Run bulk ATAC-seq from raw reads or aligned inputs through interactive reports. |
+| [`prepare-atac`](#prepare-atac) | **Linux CLI or Linux container only.** Download public ATAC-seq reads or use local FASTQ files, then trim, align, filter, call peaks, calculate alignment coverage, and write QC files. The GUI and native macOS/Windows installations start from filtered BAM/BAI and peak BED files. |
+| [`bulk-footprinting`](#bulk-footprinting) | Run bulk ATAC-seq from BAM/BAI and peak BED inputs through interactive reports. |
 | [`atac-correct`](#atac-correct) | Estimate Tn5 sequence bias from aligned ATAC-seq fragments and subtract the expected bias contribution from the observed cut-site signal. Run this before footprint scoring. |
 | [`call-footprints`](#call-footprints) | Calculate a continuous footprint score from bias-corrected cut-site signal within accessible regions. Higher local depletion relative to flanking signal produces stronger footprint evidence. |
 | [`match-motifs`](#match-motifs) | Scan accessible regions for motif instances, measure the footprint score at each instance, and classify sample-specific bound and unbound sites. Run this when motif locations and per-sample motif summaries are needed. |
@@ -20,7 +20,7 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 | [`review-multi-comparisons`](#review-multi-comparisons) | Combine differential-footprint reports as a scalable browser bundle or one self-contained HTML report. |
 | [`run-yaml-workflow`](#run-yaml-workflow) | Run one or more fp-tools jobs from a reusable YAML configuration. |
 | [`fp-tools-gui`](#fp-tools-gui) | Launch the browser interface for configuring and running fp-tools commands. |
-| [`fp-tools-runtime`](#fp-tools-runtime) | Inspect, install, or repair the managed external-tool runtime used by raw-read and de novo motif workflows. |
+| [`fp-tools-runtime`](#fp-tools-runtime) | Inspect, install, or repair the private external-tool runtime. Linux provides raw-read and de novo motif components; macOS and Windows provide the optional de novo motif component. |
 | [`discover-motifs`](#discover-motifs) | Prepare or run de novo motif discovery from candidate footprint intervals or an existing FASTA file. |
 | [`summarize-motifs`](#summarize-motifs) | Summarize MEME, STREME, DREME, and Tomtom results in a compact report. |
 | [`pseudobulk-fragments`](#pseudobulk-fragments) | Group single-cell ATAC fragments by a cell-annotation column to create pseudobulk inputs. |
@@ -31,11 +31,10 @@ Direct CLI commands are the primary interface. Each reference includes a method 
 
 <div class="fp-api-card" markdown="1">
 
-Download public ATAC-seq reads or use local FASTQ files, then trim, align,
-filter, call peaks, calculate alignment coverage, and write QC files. Use this
-command when the analysis starts from reads; skip it when filtered BAM and peak
-files already exist. The default runtime downloads its pinned external tools
-on first use.
+**Linux CLI or Linux container only.** Download public ATAC-seq reads or use
+local FASTQ files, then trim, align, filter, call peaks, calculate alignment
+coverage, and write QC files. The GUI and native macOS/Windows installations
+start from filtered BAM/BAI and peak BED files.
 
 **Example command**
 
@@ -45,7 +44,7 @@ prepare-atac --samples metadata.tsv --genome hg38 --outdir project
 
 **Primary inputs**
 
-- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [ENCODE and local examples](get-started/workflows/bulk-atac-seq.md#start-from-fastq-files).
+- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [ENCODE and local examples](get-started/workflows/bulk-atac-seq.md#optional-fastq-preparation-on-linux).
 - `--genome` — packaged `hg38` or `mm10` reference label, or a custom label used with explicit reference options.
 - `--outdir` — project directory represented by `{project}` below.
 
@@ -163,23 +162,23 @@ options:
 
 <div class="fp-api-card" markdown="1">
 
-Run bulk ATAC-seq from raw reads or aligned inputs through interactive reports.
+Run bulk ATAC-seq from BAM/BAI and peak BED inputs through interactive reports.
 
 The [bulk workflow guide](get-started/workflows/bulk-atac-seq.md) provides a runnable
-six-sample ENCODE design and the complete seven-cell-line tables.
+HepG2-versus-K562 ENCODE example.
 
 **Example command**
 
 ```bash
-bulk-footprinting --reads-table reads.tsv --comparison-table comparisons.tsv --genome hg38 \
+bulk-footprinting --sample-table samples.tsv --comparison-table comparisons.tsv --genome hg38.fa.gz \
   --outdir project --cores 8
 ```
 
 **Primary inputs**
 
-- `--reads-table` — sample, condition, and local FASTQ or public run-accession columns.
+- `--sample-table` — sample, condition, coordinate-sorted BAM, and peak BED columns.
 - `--comparison-table` — comparison, condition 1, and condition 2 columns.
-- `--genome` — `hg38`, `mm10`, or a custom genome label.
+- `--genome` — reference FASTA matching the BAM and peak coordinates.
 - `--outdir` — project output directory.
 - `--cores` — total worker cores.
 
@@ -200,10 +199,9 @@ bulk-footprinting --reads-table reads.tsv --comparison-table comparisons.tsv --g
 | `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for the workflow stages. |
 | `{project}/logs/bulk_footprinting/{stage}.stdout.log` and `{stage}.stderr.log` | Stage-specific logs for troubleshooting. |
 
-Use `--sample-table` instead of `--reads-table` to start from prepared BAM and
-peak files. `--runtime auto` downloads the pinned external tools only when raw
-reads require them. `--runtime system` and `--runtime container` are optional
-advanced backends.
+Linux CLI and Linux container users may instead use `--reads-table` for FASTQ
+or public-run preprocessing. This option and its associated preparation flags
+are unavailable in the GUI and native macOS/Windows installations.
 
 **Complete options**
 
@@ -233,8 +231,9 @@ options:
   --sample-table SAMPLE_TABLE
                         TSV with sample, condition, BAM, and peak BED columns.
   --reads-table READS_TABLE
-                        TSV/CSV with local FASTQ paths or public run
-                        accessions; runs preparation before footprinting.
+                        Linux CLI/container only: TSV/CSV with local FASTQ
+                        paths or public run accessions; runs preparation
+                        before footprinting.
   --comparison-table COMPARISON_TABLE
                         TSV with comparison, cond1, and cond2 columns.
   --genome GENOME       Reference FASTA for aligned input, or hg38/mm10/custom
@@ -1543,6 +1542,10 @@ options:
 
 Launch the browser interface for configuring and running fp-tools commands.
 
+Bulk GUI workflows start from coordinate-sorted BAM/BAI files and matching
+peak BED files. The GUI does not perform FASTQ-to-BAM preprocessing.
+Missing inputs and unsupported options are reported before a run starts.
+
 The GUI is available through the Python package, the complete container, and
 the self-contained desktop downloads on the
 [release page](https://github.com/oncologylab/fp-tools/releases).
@@ -1615,8 +1618,9 @@ options:
 
 <div class="fp-api-card" markdown="1">
 
-Inspect, install, or repair the private external-tool runtime used by raw-read
-and de novo motif workflows.
+Inspect, install, or repair the private external-tool runtime. Linux provides
+raw-read and de novo motif components; macOS and Windows provide the optional
+de novo motif component.
 
 **Example command**
 
@@ -1631,8 +1635,9 @@ The `status` action takes no input files.
 **Main outputs**
 
 The command reports each runtime component, platform, installation state, and
-cache location. `install core` prepares raw-read tools; MEME Suite and HOMER
-components are installed only when requested by their workflows.
+cache location. `install core` and `install homer` are Linux-only raw-read
+components. The MEME Suite component is installed only when requested by de
+novo motif discovery.
 
 **Complete options**
 

--- a/docs/get-started/commands/atac-correct.md
+++ b/docs/get-started/commands/atac-correct.md
@@ -1,8 +1,8 @@
 ---
 core_nav:
   previous:
-    title: prepare-atac
-    url: get-started/commands/prepare-atac/
+    title: Tool overview
+    url: get-started/tool-overview/
   next:
     title: call-footprints
     url: get-started/commands/call-footprints/

--- a/docs/get-started/commands/bulk-footprinting.md
+++ b/docs/get-started/commands/bulk-footprinting.md
@@ -1,22 +1,22 @@
 # [`bulk-footprinting`](../../api.md#bulk-footprinting)
 
-Run bulk ATAC-seq from raw reads or aligned inputs through interactive reports.
+Run bulk ATAC-seq from BAM/BAI and peak BED inputs through interactive reports.
 
 The [bulk workflow guide](../workflows/bulk-atac-seq.md) provides a runnable
-HepG2-versus-K562 ENCODE example from FASTQ or aligned inputs.
+HepG2-versus-K562 ENCODE example.
 
 ## Example command
 
 ```bash
-bulk-footprinting --reads-table reads.tsv --comparison-table comparisons.tsv --genome hg38 \
+bulk-footprinting --sample-table samples.tsv --comparison-table comparisons.tsv --genome hg38.fa.gz \
   --outdir project --cores 8
 ```
 
 ## Primary inputs
 
-- `--reads-table` — sample, condition, and local FASTQ or public run-accession columns.
+- `--sample-table` — sample, condition, coordinate-sorted BAM, and peak BED columns.
 - `--comparison-table` — comparison, condition 1, and condition 2 columns.
-- `--genome` — `hg38`, `mm10`, or a custom genome label.
+- `--genome` — reference FASTA matching the BAM and peak coordinates.
 - `--outdir` — project output directory.
 - `--cores` — total worker cores.
 
@@ -37,7 +37,6 @@ bulk-footprinting --reads-table reads.tsv --comparison-table comparisons.tsv --g
 | `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for the workflow stages. |
 | `{project}/logs/bulk_footprinting/{stage}.stdout.log` and `{stage}.stderr.log` | Stage-specific logs for troubleshooting. |
 
-Use `--sample-table` instead of `--reads-table` to start from prepared BAM and
-peak files. `--runtime auto` downloads the pinned external tools only when raw
-reads require them. `--runtime system` and `--runtime container` are optional
-advanced backends.
+Linux CLI and Linux container users may instead use `--reads-table` for FASTQ
+or public-run preprocessing. This option and its associated preparation flags
+are unavailable in the GUI and native macOS/Windows installations.

--- a/docs/get-started/commands/fp-tools-gui.md
+++ b/docs/get-started/commands/fp-tools-gui.md
@@ -2,6 +2,10 @@
 
 Launch the browser interface for configuring and running fp-tools commands.
 
+Bulk GUI workflows start from coordinate-sorted BAM/BAI files and matching
+peak BED files. The GUI does not perform FASTQ-to-BAM preprocessing.
+Missing inputs and unsupported options are reported before a run starts.
+
 The GUI is available through the Python package, the complete container, and
 the self-contained desktop downloads on the
 [release page](https://github.com/oncologylab/fp-tools/releases).

--- a/docs/get-started/commands/fp-tools-runtime.md
+++ b/docs/get-started/commands/fp-tools-runtime.md
@@ -1,7 +1,8 @@
 # [`fp-tools-runtime`](../../api.md#fp-tools-runtime)
 
-Inspect, install, or repair the private external-tool runtime used by raw-read
-and de novo motif workflows.
+Inspect, install, or repair the private external-tool runtime. Linux provides
+raw-read and de novo motif components; macOS and Windows provide the optional
+de novo motif component.
 
 ## Example command
 
@@ -16,5 +17,6 @@ The `status` action takes no input files.
 ## Main outputs
 
 The command reports each runtime component, platform, installation state, and
-cache location. `install core` prepares raw-read tools; MEME Suite and HOMER
-components are installed only when requested by their workflows.
+cache location. `install core` and `install homer` are Linux-only raw-read
+components. The MEME Suite component is installed only when requested by de
+novo motif discovery.

--- a/docs/get-started/commands/prepare-atac.md
+++ b/docs/get-started/commands/prepare-atac.md
@@ -1,17 +1,9 @@
----
-core_nav:
-  next:
-    title: atac-correct
-    url: get-started/commands/atac-correct/
----
-
 # [`prepare-atac`](../../api.md#prepare-atac)
 
-Download public ATAC-seq reads or use local FASTQ files, then trim, align,
-filter, call peaks, calculate alignment coverage, and write QC files. Use this
-command when the analysis starts from reads; skip it when filtered BAM and peak
-files already exist. The default runtime downloads its pinned external tools
-on first use.
+**Linux CLI or Linux container only.** Download public ATAC-seq reads or use
+local FASTQ files, then trim, align, filter, call peaks, calculate alignment
+coverage, and write QC files. The GUI and native macOS/Windows installations
+start from filtered BAM/BAI and peak BED files.
 
 ## Example command
 
@@ -21,7 +13,7 @@ prepare-atac --samples metadata.tsv --genome hg38 --outdir project
 
 ## Primary inputs
 
-- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [ENCODE and local examples](../workflows/bulk-atac-seq.md#start-from-fastq-files).
+- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [ENCODE and local examples](../workflows/bulk-atac-seq.md#optional-fastq-preparation-on-linux).
 - `--genome` — packaged `hg38` or `mm10` reference label, or a custom label used with explicit reference options.
 - `--outdir` — project directory represented by `{project}` below.
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -5,8 +5,8 @@ hide:
 
 # Installation
 
-Choose the recommended option for your computer. fp-tools installs its Python
-dependencies and downloads any required genomics tools automatically.
+Choose the recommended option for your computer. Every GUI and desktop route
+starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 
 | Computer | Recommended installation |
 | --- | --- |
@@ -19,14 +19,13 @@ dependencies and downloads any required genomics tools automatically.
 Download the app for your computer, then open it. The GUI starts in your
 browser.
 
-[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc6/fp-tools-gui-windows-x64.exe){ .md-button }
-[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc6/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
+[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc7/fp-tools-gui-windows-x64.exe){ .md-button }
+[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc7/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
 The preview apps are unsigned. Windows may ask you to confirm the download. On
 macOS, Control-click the app and choose **Open** the first time.
 
-The first FASTQ or de novo motif-discovery run prepares the complete analysis
-environment automatically. On Windows, enabling WSL2 may require one restart.
+Optional de novo motif discovery prepares its external tools on first use.
 
 ## Python package
 
@@ -61,6 +60,9 @@ server address. The port must be permitted by the server firewall.
     ```
 
     Open `http://127.0.0.1:8891`. Your current folder is available as `/work`.
+
+    The Linux container also supports FASTQ-to-BAM preparation with
+    `prepare-atac`; native Windows and macOS installations do not.
 
 ## Start an analysis
 

--- a/docs/get-started/output-examples/bulk-atac-seq.md
+++ b/docs/get-started/output-examples/bulk-atac-seq.md
@@ -12,4 +12,4 @@ motif search, volcano plots, motif logos, aggregate profiles, and SVG export.
   </iframe>
 </div>
 
-[Open the complete Bulk output demo](../../reports.md)
+[Open the complete Bulk output demo](../../reports.md){ target="_blank" rel="noopener noreferrer" }

--- a/docs/get-started/tool-overview.md
+++ b/docs/get-started/tool-overview.md
@@ -4,12 +4,12 @@ The guides below cover common inputs and outputs. See the
 [API Reference](../api.md) for every option.
 
 If you are new to fp-tools, start with the [bulk ATAC-seq workflow](workflows/bulk-atac-seq.md):
-it includes complete FASTQ and aligned-data sample sheets, an explicit
-comparison table, ENCODE downloads, and the expected output layout.
+it includes a BAM/peak sample sheet, an explicit comparison table, ENCODE
+downloads, and the expected output layout. A separate section on the same page
+covers optional Linux-only FASTQ preparation.
 
 ## Core analysis
 
-- [`prepare-atac`](commands/prepare-atac.md) — prepare FASTQ inputs as filtered BAM, peak, alignment coverage, and QC outputs.
 - [`atac-correct`](commands/atac-correct.md) — correct ATAC-seq cut-site signal for Tn5 sequence bias.
 - [`call-footprints`](commands/call-footprints.md) — calculate footprint-score tracks from corrected signal.
 - [`match-motifs`](commands/match-motifs.md) — scan motifs and summarize motif-associated footprint scores.
@@ -23,11 +23,15 @@ comparison table, ENCODE downloads, and the expected output layout.
 
 ## Workflow and interface
 
-- [`bulk-footprinting`](commands/bulk-footprinting.md) — run the complete bulk workflow from raw reads or aligned inputs.
+- [`bulk-footprinting`](commands/bulk-footprinting.md) — run the complete bulk workflow from BAM/BAI and peak BED inputs.
 - [`sc-footprinting`](commands/sc-footprinting.md) — run pseudobulk and per-cell single-cell ATAC-seq footprinting.
 - [`run-yaml-workflow`](commands/run-yaml-workflow.md) — run command-compatible jobs from YAML.
 - [`fp-tools-gui`](commands/fp-tools-gui.md) — launch the browser interface.
 - [`fp-tools-runtime`](commands/fp-tools-runtime.md) — inspect or prepare the managed external-tool runtime.
+
+## Linux preprocessing
+
+- [`prepare-atac`](commands/prepare-atac.md) — prepare FASTQ inputs as filtered BAM, peak, alignment coverage, and QC outputs from the Linux CLI or Linux container.
 
 ## De Novo Motif Discovery
 

--- a/docs/get-started/workflows/bulk-atac-seq.md
+++ b/docs/get-started/workflows/bulk-atac-seq.md
@@ -1,26 +1,14 @@
 # Bulk ATAC-seq workflow
 
-`bulk-footprinting` runs a complete bulk ATAC-seq analysis from FASTQ files or
-prepared BAM and peak files. It produces footprint scores, differential motif
-results, and an interactive report.
+`bulk-footprinting` runs a complete bulk ATAC-seq analysis from prepared BAM/BAI
+and peak BED files. It produces footprint scores, differential motif results,
+and an interactive report.
 
 This example compares three HepG2 and three K562 biological replicates from
 ENCODE experiments [ENCSR291GJU](https://www.encodeproject.org/experiments/ENCSR291GJU/)
 and [ENCSR868FGK](https://www.encodeproject.org/experiments/ENCSR868FGK/).
 
-## Start from FASTQ files
-
-Download the [ENCODE FASTQ sample sheet](../../demos/data/encode/encode_hepg2_k562_fastq_urls.tsv)
-and the [HepG2/K562 comparison file](../../demos/data/encode/encode_hepg2_k562_comparisons.tsv).
-For your own data, begin with the [local FASTQ template](../../demos/data/encode/local_fastq_template.tsv).
-
-```bash
-bulk-footprinting --reads-table encode_hepg2_k562_fastq_urls.tsv \
-  --comparison-table encode_hepg2_k562_comparisons.tsv --genome hg38 \
-  --outdir project --cores 8
-```
-
-## Start from aligned files
+## Run from aligned files
 
 Download the [ENCODE BAM and peak sample sheet](../../demos/data/encode/encode_hepg2_k562_bams.tsv)
 and its [download helper](../../demos/data/encode/download_encode_hepg2_k562.sh).
@@ -37,6 +25,22 @@ bulk-footprinting --sample-table encode_hepg2_k562_bams.tsv \
 
 Repeated condition names in a sample sheet define biological replicates. BAM,
 peak, blacklist, and genome files must use the same genome assembly.
+
+## Optional FASTQ preparation on Linux
+
+The Linux CLI and Linux container can also run the workflow from local FASTQ
+files or public run accessions. This route is not exposed in any GUI or native
+macOS/Windows installation.
+
+Download the [ENCODE FASTQ sample sheet](../../demos/data/encode/encode_hepg2_k562_fastq_urls.tsv)
+and the [HepG2/K562 comparison file](../../demos/data/encode/encode_hepg2_k562_comparisons.tsv).
+For your own data, begin with the [local FASTQ template](../../demos/data/encode/local_fastq_template.tsv).
+
+```bash
+bulk-footprinting --reads-table encode_hepg2_k562_fastq_urls.tsv \
+  --comparison-table encode_hepg2_k562_comparisons.tsv --genome hg38 \
+  --outdir project --cores 8
+```
 
 ## Review the results
 

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -9,6 +9,10 @@ hide:
 The GUI runs the same fp-tools commands and saves reusable YAML
 configurations.
 
+Bulk GUI workflows start from coordinate-sorted BAM/BAI files and matching
+peak BED files. FASTQ-to-BAM preparation is available separately through the
+Linux CLI or Linux container.
+
 ```bash
 fp-tools-gui
 ```
@@ -22,10 +26,10 @@ fp-tools-gui
   </iframe>
 </div>
 
-<a href="../demos/gui/fp-tools-gui-static-demo.html">Open the GUI demonstration in a full page</a>
+<a href="../demos/gui/fp-tools-gui-static-demo.html" target="_blank" rel="noopener noreferrer">Open the GUI demonstration in a full page</a>
 
-Example configurations are in `examples/gui_configs/` and can also be run
-directly:
+The GUI includes example configurations. Repository copies under
+`examples/gui_configs/` can also be run directly:
 
 ```bash
 run-yaml-workflow --config examples/gui_configs/call_footprints_single.yml

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,17 +23,19 @@ motif analysis, replicate comparisons, and reusable reports.
   <span>MIT license</span>
 </div>
 
-- Process raw reads or start from aligned Tn5-based chromatin data.
+- Analyze aligned Tn5-based chromatin data from BAM and peak files.
 - Compare motif-associated footprint scores across samples and replicates.
 - Analyze pseudobulk and per-cell footprint signatures.
 - Export static figures and portable interactive HTML reports.
 
 Choose your starting point:
 
-- **FASTQ files:** prepare and QC reads with [`prepare-atac`](get-started/commands/prepare-atac.md).
-- **BAM and peak files:** follow the runnable [bulk ATAC-seq workflow](get-started/workflows/bulk-atac-seq.md).
+- **BAM/BAI and peak BED files:** follow the runnable [bulk ATAC-seq workflow](get-started/workflows/bulk-atac-seq.md).
 - **Single-cell fragments:** follow the [single-cell workflow](get-started/workflows/single-cell.md).
 - **Existing fp-tools outputs:** open the [output demo](reports.md) or choose a command in the [tool overview](get-started/tool-overview.md).
+
+Linux command-line and container users can optionally prepare FASTQ files with
+[`prepare-atac`](get-started/commands/prepare-atac.md).
 
 [Install fp-tools](get-started/installation.md){ .fp-text-link }
 &nbsp;·&nbsp;

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -18,4 +18,4 @@ motif statistics, logos, and aggregate profiles.
   </iframe>
 </div>
 
-<a href="../ENCODE-Cancer-Cell-lines-Footprinting/">Open the output demo in a full page</a>
+<a href="../ENCODE-Cancer-Cell-lines-Footprinting/" target="_blank" rel="noopener noreferrer">Open the output demo in a full page</a>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -529,7 +529,7 @@ textarea {
   }
 
   .fp-page-tool-overview .md-typeset li {
-    font-size: 0.76rem;
+    font-size: 0.74rem;
     line-height: 1.4;
     margin: 0.12rem 0;
     white-space: nowrap;

--- a/examples/gui_configs/bulk_footprinting_bam.yml
+++ b/examples/gui_configs/bulk_footprinting_bam.yml
@@ -1,0 +1,15 @@
+version: 1
+run_mode: single
+defaults: {}
+samples:
+  - sample_id: bulk_footprinting_bam
+    tool: bulk-footprinting
+    sample_table: docs/demos/data/encode/encode_hepg2_k562_bams.tsv
+    comparison_table: docs/demos/data/encode/encode_hepg2_k562_comparisons.tsv
+    genome: hg38.fa.gz
+    blacklist: hg38.blacklist.bed
+    motif_db: jaspar2026_vertebrates
+    outdir: examples/gui_demo_outputs/bulk_footprinting
+    cores: 4
+    dry_run: true
+comparisons: []

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc6
+#      python -m pip install fp-tools-bio==0.2.0rc7
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc6}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc7}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,12 +54,13 @@ nav:
           - De novo motif discovery: get-started/workflows/de-novo-motif-discovery.md
       - Commands:
           - Core analysis:
-              - prepare-atac: get-started/commands/prepare-atac.md
               - atac-correct: get-started/commands/atac-correct.md
               - call-footprints: get-started/commands/call-footprints.md
               - match-motifs: get-started/commands/match-motifs.md
               - diff-footprints: get-started/commands/diff-footprints.md
               - normalize-bigwig: get-started/commands/normalize-bigwig.md
+          - Linux preprocessing:
+              - prepare-atac: get-started/commands/prepare-atac.md
           - Visualization and review:
               - plot-aggregate: get-started/commands/plot-aggregate.md
               - review-multi-comparisons: get-started/commands/review-multi-comparisons.md

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc6</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc7</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/packaging/desktop/fp-tools-gui.spec
+++ b/packaging/desktop/fp-tools-gui.spec
@@ -1,9 +1,10 @@
 # -*- mode: python ; coding: utf-8 -*-
 """Cross-platform one-file fp-tools GUI bundle."""
 
+from importlib.util import find_spec
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_all, copy_metadata
+from PyInstaller.utils.hooks import collect_all, collect_data_files, copy_metadata
 
 
 root = Path.cwd().resolve()
@@ -18,6 +19,26 @@ for package in ("fp_tools", "streamlit"):
     datas += package_data
     binaries += package_binaries
     hiddenimports += package_hidden
+
+# Cython modules are imported lazily by several command targets. Resolve their
+# installed extension files explicitly so one-file bundles cannot silently
+# fall back to the source-only package tree.
+for module in (
+    "fp_tools.utils.sequences",
+    "fp_tools.utils.ngs",
+    "fp_tools.utils.signals",
+):
+    module_spec = find_spec(module)
+    if module_spec is None or not module_spec.origin:
+        raise RuntimeError(f"Desktop build is missing compiled extension {module}")
+    binaries.append((module_spec.origin, "fp_tools/utils"))
+    hiddenimports.append(module)
+
+# Windows uses bamnostic in place of pysam. bamnostic reads its version from a
+# package-data file during import, including for command --help.
+if find_spec("bamnostic") is not None:
+    datas += collect_data_files("bamnostic")
+    hiddenimports.append("bamnostic")
 
 for distribution in ("fp-tools-bio", "streamlit"):
     datas += copy_metadata(distribution, recursive=True)
@@ -41,6 +62,8 @@ analysis = Analysis(
     hookspath=[],
     runtime_hooks=[],
     excludes=[
+        "fp_tools.tools.prepare_atac",
+        "fp_tools.tools.prepare_atac_legacy",
         "pytest",
         "sphinx",
         "mkdocs",

--- a/packaging/desktop/launcher.py
+++ b/packaging/desktop/launcher.py
@@ -1,7 +1,10 @@
 """PyInstaller entry script for fp-tools GUI release bundles."""
 
-from fp_tools.desktop import main
+import multiprocessing
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    from fp_tools.desktop import main
+
     raise SystemExit(main())

--- a/packaging/runtime/windows-meme.Dockerfile
+++ b/packaging/runtime/windows-meme.Dockerfile
@@ -1,0 +1,26 @@
+FROM mambaorg/micromamba:2.0.5
+
+LABEL org.opencontainers.image.source="https://github.com/oncologylab/fp-tools"
+
+WORKDIR /opt/fp-tools
+ENV FP_TOOLS_RUNTIME=system
+USER root
+RUN chown "$MAMBA_USER:$MAMBA_USER" /opt/fp-tools
+USER $MAMBA_USER
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER packaging/runtime/meme.yml /tmp/fp-tools-runtime-meme.yml
+RUN micromamba install -y -n base -f /tmp/fp-tools-runtime-meme.yml \
+    && micromamba clean --all --yes
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml setup.py README.md LICENSE ./
+COPY --chown=$MAMBA_USER:$MAMBA_USER src ./src
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev \
+    && micromamba run -n base python -m pip install --no-cache-dir . \
+    && micromamba run -n base python -m pip check \
+    && apt-get purge -y --auto-remove gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/* /root/.cache/pip
+USER $MAMBA_USER
+
+WORKDIR /work

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc6"
+version = "0.2.0rc7"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -122,6 +122,7 @@ include = ["fp_tools*"]
 "fp_tools.utils" = ["*.pyx", "*.pxd"]
 "fp_tools.resources.motifs" = ["*.txt"]
 "fp_tools.resources" = ["*.json"]
+"fp_tools.resources.gui_configs" = ["*.yml"]
 "fp_tools.resources.static_browser" = ["*.html", "*.js", "*.css"]
 
 [tool.pytest.ini_options]
@@ -146,12 +147,17 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc6"
+version = "0.2.0rc7"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"
 packages = [{ include = "fp_tools", from = "src" }]
-include = ["src/fp_tools/resources/motifs/*.txt", "src/fp_tools/resources/static_browser/*"]
+include = [
+  "src/fp_tools/resources/motifs/*.txt",
+  "src/fp_tools/resources/static_browser/*",
+  "src/fp_tools/resources/gui_configs/*.yml",
+  "src/fp_tools/resources/runtime_manifest.json"
+]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"

--- a/scripts/audit_desktop_gui.py
+++ b/scripts/audit_desktop_gui.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Browser-level responsive audit for a frozen fp-tools desktop GUI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import signal
+import subprocess
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as handle:
+        handle.bind(("127.0.0.1", 0))
+        return int(handle.getsockname()[1])
+
+
+def _wait_for_health(url: str, process: subprocess.Popen[str], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("Desktop GUI exited before browser audit")
+        try:
+            with urllib.request.urlopen(url + "/_stcore/health", timeout=2) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.5)
+    raise RuntimeError("Desktop GUI health check timed out")
+
+
+def _stop(process: subprocess.Popen[str]) -> None:
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    try:
+        process.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            process.kill()
+        else:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        process.wait(timeout=20)
+
+
+def _audit_page(
+    browser,
+    base_url: str,
+    page_name: str,
+    width: int,
+    height: int,
+    output: Path,
+    capture_screenshots: bool,
+) -> None:
+    context = browser.new_context(viewport={"width": width, "height": height})
+    page = context.new_page()
+    page.goto(
+        f"{base_url}/?page={urllib.parse.quote(page_name)}",
+        wait_until="domcontentloaded",
+    )
+    page.locator(".fp-page-heading h1", has_text=page_name).wait_for(timeout=60_000)
+    summary = page.locator(".fp-run-summary").first
+    summary.wait_for(timeout=30_000)
+    metrics = summary.evaluate(
+        """element => ({
+          columns: getComputedStyle(element).gridTemplateColumns.split(' ').filter(Boolean).length,
+          wordBreaks: [...element.querySelectorAll('strong')].map(node => getComputedStyle(node).wordBreak),
+          overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth
+        })"""
+    )
+    expected_columns = 3 if width > 1500 else (2 if width > 900 else 1)
+    if metrics["columns"] != expected_columns:
+        raise RuntimeError(
+            f"{page_name} at {width}px uses {metrics['columns']} run-summary columns; "
+            f"expected {expected_columns}"
+        )
+    if set(metrics["wordBreaks"]) - {"normal"}:
+        raise RuntimeError(f"{page_name} at {width}px permits mid-word summary breaks")
+    if metrics["overflow"]:
+        raise RuntimeError(f"{page_name} at {width}px has horizontal overflow")
+    if capture_screenshots:
+        page.screenshot(
+            path=str(output / f"{page_name}-{width}.png"),
+            full_page=False,
+            animations="disabled",
+            timeout=30_000,
+        )
+    print(f"Audited {page_name} at {width}x{height}", flush=True)
+    context.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable")
+    parser.add_argument("--output-dir", default="desktop-gui-audit")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--skip-screenshots",
+        action="store_true",
+        help="Run geometry checks without writing screenshots (useful on headless hosts).",
+    )
+    args = parser.parse_args()
+
+    executable = Path(args.executable).resolve()
+    output = Path(args.output_dir).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    with tempfile.TemporaryDirectory(prefix="fp-tools-desktop-browser-") as workdir:
+        process = subprocess.Popen(
+            [str(executable), "--no-browser", "--port", str(port), "--run-dir", str(Path(workdir) / "runs")],
+            cwd=workdir,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env={**os.environ, "STREAMLIT_BROWSER_GATHER_USAGE_STATS": "false"},
+            start_new_session=os.name != "nt",
+        )
+        try:
+            _wait_for_health(base_url, process, args.timeout)
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch(
+                    headless=True,
+                    args=["--disable-dev-shm-usage"],
+                )
+                try:
+                    for page_name in ("plot-aggregate", "bulk-footprinting", "review-multi-comparisons"):
+                        for width, height in ((1920, 1080), (1280, 720), (390, 844)):
+                            _audit_page(
+                                browser,
+                                base_url,
+                                page_name,
+                                width,
+                                height,
+                                output,
+                                not args.skip_screenshots,
+                            )
+
+                    context = browser.new_context(viewport={"width": 1280, "height": 720})
+                    page = context.new_page()
+                    page.goto(f"{base_url}/?page=bulk-footprinting", wait_until="domcontentloaded")
+                    page.locator(".fp-page-heading h1", has_text="bulk-footprinting").wait_for(
+                        timeout=60_000
+                    )
+                    loader = page.locator("details", has_text="Load bulk-footprinting config").first
+                    loader.wait_for(timeout=30_000)
+                    loader.evaluate("element => { element.open = true; }")
+                    page.get_by_text("Example YAML", exact=True).wait_for(timeout=30_000)
+                    page.get_by_role("button", name="Load example", exact=True).wait_for(timeout=30_000)
+                    page.get_by_text("Config needs fixes before launch.", exact=True).wait_for(timeout=30_000)
+                    if page.get_by_text("Reads Table", exact=True).count():
+                        raise RuntimeError("Desktop GUI unexpectedly exposes a FASTQ reads-table field")
+                    context.close()
+                finally:
+                    browser.close()
+        finally:
+            _stop(process)
+    if args.skip_screenshots:
+        print("Desktop GUI browser audit passed (screenshots skipped on this headless host)")
+    else:
+        print(f"Desktop GUI browser audit passed; screenshots: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_docs.py
+++ b/scripts/audit_docs.py
@@ -47,7 +47,6 @@ GET_STARTED_PAGES = (
     "get-started/output-examples/region-set-comparison/",
 )
 CORE_COMMAND_SEQUENCE = (
-    "get-started/commands/prepare-atac/",
     "get-started/commands/atac-correct/",
     "get-started/commands/call-footprints/",
     "get-started/commands/match-motifs/",
@@ -575,7 +574,7 @@ def audit(site_dir: Path) -> None:
                         next_count = page.locator(".md-footer__link--next").count()
                         if relative in CORE_COMMAND_SEQUENCE:
                             index = CORE_COMMAND_SEQUENCE.index(relative)
-                            expected_previous = int(index > 0)
+                            expected_previous = 1
                             expected_next = int(index < len(CORE_COMMAND_SEQUENCE) - 1)
                             if previous_count != expected_previous:
                                 failures.append(

--- a/scripts/smoke_desktop_bundle.py
+++ b/scripts/smoke_desktop_bundle.py
@@ -97,7 +97,7 @@ def main() -> int:
                 "--signals",
                 str(fixture_root / "Bcell_corrected.bw"),
                 "--regions",
-                str(fixture_root / "merged_peaks.bed"),
+                str(fixture_root / "plot_regions.bed"),
                 "--outdir",
                 str(call_output),
                 "--score",

--- a/scripts/smoke_desktop_bundle.py
+++ b/scripts/smoke_desktop_bundle.py
@@ -125,7 +125,7 @@ def main() -> int:
                 str(fixture_root / "Bcell_corrected.bw"),
                 str(fixture_root / "Tcell_corrected.bw"),
                 "--background",
-                str(fixture_root / "merged_peaks.bed"),
+                str(fixture_root / "plot_regions.bed"),
                 "--outdir",
                 str(normalize_output),
                 "--method",

--- a/scripts/smoke_desktop_bundle.py
+++ b/scripts/smoke_desktop_bundle.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 import argparse
 import os
 import socket
+import signal
 import subprocess
 import tempfile
 import time
 import urllib.request
 from pathlib import Path
-
 
 def free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as handle:
@@ -30,11 +30,20 @@ def stop_process_tree(process: subprocess.Popen[str]) -> str:
             check=False,
         )
     else:
-        process.terminate()
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return ""
     try:
         return process.communicate(timeout=20)[0] or ""
     except subprocess.TimeoutExpired:
-        process.kill()
+        if os.name == "nt":
+            process.kill()
+        else:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
         return process.communicate(timeout=20)[0] or ""
 
 
@@ -46,22 +55,108 @@ def main() -> int:
 
     executable = Path(args.executable).resolve()
     help_run = subprocess.run(
-        [str(executable), "--fp-tools-internal-command", "summarize-motifs", "--help"],
+        [str(executable), "--fp-tools-internal-smoke-command-helps"],
         capture_output=True,
         text=True,
         timeout=args.timeout,
     )
-    if help_run.returncode != 0 or "Summarize MEME/Tomtom" not in help_run.stdout:
-        raise SystemExit(f"Internal command dispatch failed:\n{help_run.stdout}\n{help_run.stderr}")
+    if help_run.returncode != 0 or "Validated " not in help_run.stdout:
+        raise SystemExit(
+            f"Internal command dispatch audit failed:\n{help_run.stdout}\n{help_run.stderr}"
+        )
 
-    port = free_port()
+    raw_read_run = subprocess.run(
+        [str(executable), "--fp-tools-internal-command", "prepare-atac", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=args.timeout,
+    )
+    if raw_read_run.returncode == 0:
+        raise SystemExit("Desktop bundle unexpectedly exposes prepare-atac")
+
+    examples_run = subprocess.run(
+        [str(executable), "--fp-tools-internal-list-gui-examples"],
+        capture_output=True,
+        text=True,
+        timeout=args.timeout,
+    )
+    if examples_run.returncode != 0 or "bulk_footprinting_bam.yml" not in examples_run.stdout:
+        raise SystemExit(
+            f"Desktop bundle is missing GUI examples:\n{examples_run.stdout}\n{examples_run.stderr}"
+        )
+
     with tempfile.TemporaryDirectory(prefix="fp-tools-desktop-smoke-") as run_dir:
+        run_path = Path(run_dir)
+        fixture_root = Path(__file__).resolve().parents[1] / "test_data"
+        call_output = run_path / "call_footprints"
+        call_run = subprocess.run(
+            [
+                str(executable),
+                "--fp-tools-internal-command",
+                "call-footprints",
+                "--signals",
+                str(fixture_root / "Bcell_corrected.bw"),
+                "--regions",
+                str(fixture_root / "merged_peaks.bed"),
+                "--outdir",
+                str(call_output),
+                "--score",
+                "footprint",
+                "--cores",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=args.timeout,
+            cwd=run_dir,
+        )
+        if call_run.returncode != 0 or not any(call_output.glob("*.bw")):
+            raise SystemExit(
+                f"Frozen call-footprints smoke failed:\n{call_run.stdout}\n{call_run.stderr}"
+            )
+
+        normalize_output = run_path / "normalize_bigwig"
+        normalize_run = subprocess.run(
+            [
+                str(executable),
+                "--fp-tools-internal-command",
+                "normalize-bigwig",
+                "--bigwigs",
+                str(fixture_root / "Bcell_corrected.bw"),
+                str(fixture_root / "Tcell_corrected.bw"),
+                "--background",
+                str(fixture_root / "merged_peaks.bed"),
+                "--outdir",
+                str(normalize_output),
+                "--method",
+                "background-scale",
+                "--stat",
+                "q95",
+                "--target",
+                "median",
+                "--workers",
+                "2",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=args.timeout,
+            cwd=run_dir,
+        )
+        if normalize_run.returncode != 0 or len(list(normalize_output.glob("*.bw"))) != 2:
+            raise SystemExit(
+                "Frozen multiprocessing normalize-bigwig smoke failed:\n"
+                f"{normalize_run.stdout}\n{normalize_run.stderr}"
+            )
+
+        port = free_port()
         process = subprocess.Popen(
             [str(executable), "--no-browser", "--port", str(port), "--run-dir", run_dir],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            cwd=run_dir,
             env={**os.environ, "STREAMLIT_BROWSER_GATHER_USAGE_STATS": "false"},
+            start_new_session=os.name != "nt",
         )
         try:
             deadline = time.monotonic() + args.timeout

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc6"
+__version__ = "0.2.0rc7"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/command_registry.py
+++ b/src/fp_tools/command_registry.py
@@ -13,7 +13,6 @@ from collections.abc import Callable, Sequence
 
 
 COMMAND_TARGETS: dict[str, str] = {
-    "prepare-atac": "fp_tools.tools.prepare_atac:main",
     "bulk-footprinting": "fp_tools.tools.bulk_footprinting:main",
     "atac-correct": "fp_tools.cli:main",
     "call-footprints": "fp_tools.cli_scorebigwig:main",

--- a/src/fp_tools/desktop.py
+++ b/src/fp_tools/desktop.py
@@ -11,12 +11,37 @@ from fp_tools.command_registry import dispatch_command
 INTERNAL_COMMAND_FLAG = "--fp-tools-internal-command"
 INTERNAL_MATCH_BEDS_FLAG = "--fp-tools-internal-match-beds"
 INTERNAL_PYTHON_SCRIPT_FLAG = "--fp-tools-internal-python-script"
+INTERNAL_LIST_EXAMPLES_FLAG = "--fp-tools-internal-list-gui-examples"
+INTERNAL_SMOKE_HELPS_FLAG = "--fp-tools-internal-smoke-command-helps"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Launch the GUI, or dispatch a child command inside a frozen bundle."""
 
     arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments and arguments[0] == INTERNAL_SMOKE_HELPS_FLAG:
+        if len(arguments) != 1:
+            raise SystemExit(f"{INTERNAL_SMOKE_HELPS_FLAG} does not accept arguments")
+        from fp_tools.command_registry import COMMAND_TARGETS
+
+        for command in sorted(COMMAND_TARGETS):
+            try:
+                dispatch_command(command, ["--help"])
+            except SystemExit as exc:
+                if exc.code not in (None, 0):
+                    raise
+        print(f"Validated {len(COMMAND_TARGETS)} desktop commands")
+        return 0
+    if arguments and arguments[0] == INTERNAL_LIST_EXAMPLES_FLAG:
+        if len(arguments) != 1:
+            raise SystemExit(f"{INTERNAL_LIST_EXAMPLES_FLAG} does not accept arguments")
+        from importlib import resources
+
+        root = resources.files("fp_tools.resources.gui_configs")
+        for path in sorted(root.iterdir(), key=lambda value: value.name):
+            if path.is_file() and path.name.endswith(".yml"):
+                print(path.name)
+        return 0
     if arguments and arguments[0] == INTERNAL_COMMAND_FLAG:
         if len(arguments) < 2:
             raise SystemExit(f"{INTERNAL_COMMAND_FLAG} requires a command name")

--- a/src/fp_tools/gui_app.py
+++ b/src/fp_tools/gui_app.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 from html import escape
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -19,17 +21,18 @@ import streamlit as st
 
 from fp_tools import __version__
 from fp_tools.gui_config import (
+    GUI_ENUM_CHOICES,
     canonical_tool_name,
     config_to_yaml_text,
     load_yaml_config,
     make_single_config,
     normalize_config,
     parse_yaml_text,
-    validate_config,
+    validate_gui_config,
 )
 from fp_tools.gui_jobs import default_gui_run_dir, launch_config_async, materialize_run_config, refresh_run_status
 
-GUI_EXAMPLE_DIR = Path("examples/gui_configs")
+GUI_EXAMPLE_PACKAGE = "fp_tools.resources.gui_configs"
 
 PAGE_OPTIONS = [
     "Home",
@@ -63,21 +66,24 @@ NAV_GROUPS = [
 GENERIC_TOOL_DEFAULTS: dict[str, dict[str, Any]] = {
     "bulk-footprinting": {
         "sample_id": "bulk_footprinting_run",
-        "reads_table": "reads.tsv",
-        "sample_table": "",
+        "sample_table": "samples.tsv",
         "comparison_table": "comparisons.tsv",
-        "genome": "hg38",
+        "genome": "genome.fa.gz",
+        "blacklist": "",
         "outdir": "results/bulk_footprinting",
         "motif_db": "jaspar2026_vertebrates",
         "plot_aggregate": "all",
         "review_format": "auto",
         "cores": 4,
-        "runtime": "auto",
     },
     "review-multi-comparisons": {
         "sample_id": "comparison_browser_run",
         "inputs": ["results/bulk_footprinting/comparisons"],
+        "labels": [],
         "output_dir": "results/bulk_footprinting/reports/review_multi_comparisons",
+        "output_html": "",
+        "layout": "custom",
+        "title": "Review multiple differential footprint comparisons",
     },
     "match-motifs": {
         "sample_id": "match_motifs_run",
@@ -98,14 +104,21 @@ GENERIC_TOOL_DEFAULTS: dict[str, dict[str, Any]] = {
         "method": "background-scale",
         "stat": "q95",
         "target": "median",
+        "chrom_sizes": "",
+        "workers": 2,
     },
     "discover-motifs": {
         "sample_id": "motif_discovery_run",
         "candidates": "test_data/merged_peaks.bed",
+        "fasta": "",
         "genome": "test_data/genome.fa.gz",
         "outdir": "examples/gui_demo_outputs/motif_discovery",
         "method": "streme",
         "known_motif_db": "jaspar2026_vertebrates",
+        "known_motifs": "",
+        "script": "",
+        "execute": False,
+        "runtime": "auto",
     },
     "summarize-motifs": {
         "sample_id": "motif_summary_run",
@@ -155,10 +168,35 @@ LIST_TEXT_FIELDS = {
     "signals",
     "bigwigs",
     "motifs",
+    "inputs",
+    "labels",
     "input_html",
     "cond_names",
+    "sample_names",
+    "sample_dirs",
+    "match_dir",
+    "aggregate_signals",
+    "region_labels",
+    "known_motifs",
     "TFBS",
     "read_shift",
+}
+
+GUI_FIELD_HELP: dict[str, dict[str, str]] = {
+    "bulk-footprinting": {
+        "normalization": "Normalization applied during differential footprinting.",
+        "plot_aggregate": "Motifs included in aggregate profiles, or off to omit profiles.",
+        "review_format": "Bundle, standalone HTML, automatic selection, or no combined report.",
+    },
+    "normalize-bigwig": {
+        "method": "Background scaling, robust z-score transformation, or no transformation.",
+        "stat": "Use median, iqr, or a quantile such as q90 or q95.",
+        "target": "Across-sample statistic used as the scaling target.",
+    },
+    "discover-motifs": {
+        "method": "MEME Suite discovery program.",
+        "runtime": "Managed, system, or container source for the optional MEME tools.",
+    },
 }
 
 
@@ -650,7 +688,9 @@ def _apply_page_style() -> None:
             color: #111827;
             font-size: 0.92rem;
             margin-top: 0.08rem;
-            word-break: break-word;
+            overflow-wrap: normal;
+            word-break: normal;
+            hyphens: none;
         }
         .fp-tutorial-panel {
             background: #eaf2ff;
@@ -676,6 +716,14 @@ def _apply_page_style() -> None:
             margin: 0.42rem 0 0;
             padding-left: 1.2rem;
         }
+        @media (max-width: 1500px) {
+            .fp-run-summary {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+            .fp-run-summary div:first-child {
+                grid-column: 1 / -1;
+            }
+        }
         @media (max-width: 900px) {
             [data-testid="stSidebar"] {
                 min-width: 300px !important;
@@ -686,6 +734,12 @@ def _apply_page_style() -> None:
             }
             .fp-run-card {
                 position: static;
+            }
+            .fp-run-summary {
+                grid-template-columns: 1fr;
+            }
+            .fp-run-summary div:first-child {
+                grid-column: auto;
             }
         }
         </style>
@@ -756,7 +810,7 @@ def _default_config_for_tool(tool: str) -> dict[str, Any]:
         defaults = {"TFBS": [], "signals": [], "output": "", "grid": "", "output_aggregated_scores": "", "output_aggregated_signals": ""}
     else:
         raw_defaults = GENERIC_TOOL_DEFAULTS.get(tool, {"sample_id": f"{tool.replace('-', '_')}_run"})
-        defaults = _prepare_generic_params(tool, _drop_single_meta(raw_defaults))
+        defaults = _drop_single_meta(raw_defaults)
     return make_single_config(tool, defaults, job_id=f"{tool.replace('-', '_')}_run")
 
 
@@ -826,17 +880,16 @@ def _render_home(run_dir: Path) -> None:
         "Remote access: launch `fp-tools-gui --host 0.0.0.0 --port 8891`, open the printed URL, "
         "and allow that TCP port in the firewall or cloud security group."
     )
-    if GUI_EXAMPLE_DIR.exists():
-        files = sorted(path.name for path in GUI_EXAMPLE_DIR.glob("*.yml"))
-        if files:
-            example_items = "\n".join(f'<div class="fp-example-item">{escape(name)}</div>' for name in files[:12])
-            st.markdown(
-                f"""
-                <div class="fp-section-title">Example YAML configs <span>{escape(str(GUI_EXAMPLE_DIR))}</span></div>
-                <div class="fp-example-grid">{example_items}</div>
-                """,
-                unsafe_allow_html=True,
-            )
+    files = [path.name for path in _all_example_files()]
+    if files:
+        example_items = "\n".join(f'<div class="fp-example-item">{escape(name)}</div>' for name in files[:12])
+        st.markdown(
+            f"""
+            <div class="fp-section-title">Example YAML configs</div>
+            <div class="fp-example-grid">{example_items}</div>
+            """,
+            unsafe_allow_html=True,
+        )
     _render_home_config_snapshot()
 
 
@@ -1312,14 +1365,14 @@ def _render_generic_tool_page(run_dir: Path, tool: str) -> None:
     with form_col:
         _render_page_loader(tool)
         defaults = GENERIC_TOOL_DEFAULTS.get(tool, {"sample_id": f"{tool.replace('-', '_')}_run"})
-        current = _current_single_params(tool) or defaults
+        current = {**_drop_single_meta(defaults), **_current_single_params(tool)}
         st.caption("This page writes the same YAML config used by run-yaml-workflow and the direct CLI.")
         with st.form(f"{tool}_generic_form"):
             edited: dict[str, Any] = {}
             simple_fields: list[tuple[str, Any]] = []
             wide_fields: list[tuple[str, Any]] = []
             for key, default_value in current.items():
-                if key in {"tool", "sample_id", "job_id", "comparison_id"}:
+                if key in {"tool", "sample_id", "job_id", "comparison_id", "extra_args"}:
                     continue
                 if key in LIST_TEXT_FIELDS or isinstance(default_value, list):
                     wide_fields.append((key, default_value))
@@ -1333,14 +1386,14 @@ def _render_generic_tool_page(run_dir: Path, tool: str) -> None:
                 edited[key] = _render_generic_field(tool, key, default_value)
             extra_args = st.text_input(
                 "Extra CLI args",
-                value=str(current.get("extra_args", "") if not isinstance(current.get("extra_args"), list) else " ".join(current.get("extra_args", []))),
+                value=_format_extra_args(current.get("extra_args", [])),
             )
             submitted = st.form_submit_button("Update page config")
         if submitted:
             config = _prepare_generic_params(tool, edited)
             if extra_args.strip():
-                config["extra_args"] = extra_args.split()
-            _set_config(make_single_config(tool, config, job_id=str(current.get("sample_id", f"{tool.replace('-', '_')}_run"))))
+                config["extra_args"] = _parse_extra_args(extra_args)
+            _set_config(make_single_config(tool, config, job_id=f"{tool.replace('-', '_')}_run"))
     with run_col:
         _render_run_controls(run_dir, label=tool.replace("-", "_"))
 
@@ -1398,7 +1451,8 @@ def _render_page_loader(tool: str) -> None:
                 key=f"{tool}_example_select",
             )
             if st.button("Load example", key=f"{tool}_load_example") and example_choice:
-                _set_config(normalize_config(load_yaml_config(GUI_EXAMPLE_DIR / example_choice)))
+                example = next(path for path in example_files if path.name == example_choice)
+                _set_config(parse_yaml_text(example.read_text(encoding="utf-8")))
         upload = st.file_uploader("Upload YAML", type=["yml", "yaml"], key=f"{tool}_uploader")
         if upload is not None and st.button("Apply uploaded YAML", key=f"{tool}_apply_upload"):
             _set_config(parse_yaml_text(upload.getvalue().decode("utf-8")))
@@ -1409,7 +1463,7 @@ def _render_page_loader(tool: str) -> None:
 
 def _render_run_controls(run_dir: Path, label: str) -> None:
     normalized = normalize_config(st.session_state.current_config)
-    validation_errors = validate_config(normalized)
+    validation_errors = validate_gui_config(normalized)
     tool = _current_config_tool() or "none"
     with st.container(border=True):
         st.markdown(
@@ -1566,15 +1620,31 @@ def _prepare_generic_params(tool: str, params: dict[str, Any]) -> dict[str, Any]
 
 def _render_generic_field(tool: str, key: str, default_value: Any) -> Any:
     value = default_value
+    help_text = GUI_FIELD_HELP.get(tool, {}).get(key)
     if isinstance(value, list):
         value = _join_multi(value)
     if isinstance(value, bool):
-        return st.checkbox(_human_label(key), value=value)
+        return st.checkbox(_human_label(key), value=value, help=help_text)
+    choices = GUI_ENUM_CHOICES.get(tool, {}).get(key)
+    if choices:
+        selected = str(value or choices[0])
+        index = choices.index(selected) if selected in choices else 0
+        return st.selectbox(
+            _human_label(key), choices, index=index, key=f"{tool}_{key}", help=help_text
+        )
     if key in LIST_TEXT_FIELDS:
-        return st.text_area(_human_label(key), value=str(value or ""), height=88, key=f"{tool}_{key}")
+        return st.text_area(
+            _human_label(key), value=str(value or ""), height=88, key=f"{tool}_{key}", help=help_text
+        )
     if isinstance(value, int):
-        return int(st.number_input(_human_label(key), min_value=0, value=int(value), step=1, key=f"{tool}_{key}"))
-    return st.text_input(_human_label(key), value=str(value or ""), key=f"{tool}_{key}")
+        return int(
+            st.number_input(
+                _human_label(key), min_value=0, value=int(value), step=1, key=f"{tool}_{key}", help=help_text
+            )
+        )
+    return st.text_input(
+        _human_label(key), value=str(value or ""), key=f"{tool}_{key}", help=help_text
+    )
 
 
 def _human_label(key: str) -> str:
@@ -1647,9 +1717,15 @@ def _drop_editor_meta(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _example_files_for_tool(tool: str) -> list[Path]:
-    if not GUI_EXAMPLE_DIR.exists():
-        return []
+def _all_example_files() -> list[Any]:
+    root = resources.files(GUI_EXAMPLE_PACKAGE)
+    return sorted(
+        (path for path in root.iterdir() if path.is_file() and path.name.endswith(".yml")),
+        key=lambda path: path.name,
+    )
+
+
+def _example_files_for_tool(tool: str) -> list[Any]:
     tool = canonical_tool_name(tool)
     prefixes = {
         "atac-correct": ["atacorrect", "atac_correct"],
@@ -1657,10 +1733,25 @@ def _example_files_for_tool(tool: str) -> list[Path]:
         "diff-footprints": ["diff_footprints"],
         "plot-aggregate": ["plotaggregate", "plot_aggregate"],
     }.get(tool, [tool.replace("-", "_")])
-    files: list[Path] = []
+    files: list[Any] = []
+    candidates = _all_example_files()
     for prefix in prefixes:
-        files.extend(GUI_EXAMPLE_DIR.glob(f"{prefix}_*.yml"))
-    return sorted(set(files))
+        files.extend(path for path in candidates if path.name.startswith(f"{prefix}_"))
+    return sorted({path.name: path for path in files}.values(), key=lambda path: path.name)
+
+
+def _parse_extra_args(text: str) -> list[str]:
+    lexer = shlex.shlex(str(text), posix=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    lexer.escape = ""
+    return list(lexer)
+
+
+def _format_extra_args(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return shlex.join([str(item) for item in (value or [])])
 
 
 def _tutorial_visible() -> bool:

--- a/src/fp_tools/gui_config.py
+++ b/src/fp_tools/gui_config.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
 
@@ -351,8 +352,12 @@ def validate_config(config: Mapping[str, Any]) -> list[str]:
                 elif str(value or "").strip() == "":
                     errors.append(f"{job_name}: missing required field '{field}'")
             if tool == "discover-motifs":
-                if not str(item.get("fasta") or "").strip() and not str(item.get("candidates") or "").strip():
+                fasta = str(item.get("fasta") or "").strip()
+                candidates = str(item.get("candidates") or "").strip()
+                if not fasta and not candidates:
                     errors.append(f"{job_name}: provide either 'fasta' or 'candidates'")
+                elif fasta and candidates:
+                    errors.append(f"{job_name}: provide only one of 'fasta' or 'candidates'")
             if tool == "bulk-footprinting":
                 reads_table = str(item.get("reads_table") or "").strip()
                 sample_table = str(item.get("sample_table") or "").strip()
@@ -405,6 +410,277 @@ def validate_config(config: Mapping[str, Any]) -> list[str]:
                     )
 
     return errors
+
+
+GUI_RAW_READ_KEYS = {
+    "reads_table",
+    "reads-table",
+    "config",
+    "profile",
+    "reference_dir",
+    "reference-dir",
+    "fasta",
+    "bowtie2_index",
+    "bowtie2-index",
+    "tss",
+    "macs_genome_size",
+    "macs-genome-size",
+    "max_parallel_samples",
+    "max-parallel-samples",
+    "memory_gb",
+    "memory-gb",
+    "keep_intermediates",
+    "keep-intermediates",
+}
+
+GUI_ENUM_CHOICES: dict[str, dict[str, tuple[str, ...]]] = {
+    "bulk-footprinting": {
+        "normalization": ("none", "condition-quantile", "sample-quantile"),
+        "plot_aggregate": ("sig", "all", "top", "off"),
+        "review_format": ("auto", "bundle", "standalone", "none"),
+    },
+    "call-footprints": {"score": ("footprint", "sum", "mean", "none")},
+    "diff-footprints": {
+        "comparison_axis": ("conditions", "regions"),
+        "normalization": ("none", "condition-quantile", "sample-quantile"),
+        "plot_aggregate": ("sig", "all", "top", "off"),
+    },
+    "normalize-bigwig": {
+        "layout": ("custom", "project"),
+        "method": ("background-scale", "background-zscore", "none"),
+        "target": ("median", "mean"),
+    },
+    "plot-aggregate": {
+        "normalization": ("none", "mean", "sum", "max", "q95"),
+        "share_y": ("none", "signals", "sites", "both"),
+    },
+    "review-multi-comparisons": {
+        "layout": ("custom", "project"),
+        "aggregate_legends": ("show", "hide"),
+    },
+    "discover-motifs": {
+        "method": ("meme", "dreme", "streme"),
+        "runtime": ("auto", "managed", "system", "container"),
+    },
+    "sc-footprinting": {
+        "diff_normalization": ("none", "condition-quantile", "sample-quantile"),
+        "diff_plot_aggregate": ("sig", "all", "top", "off"),
+    },
+}
+
+GUI_INPUT_PATH_FIELDS: dict[str, dict[str, str]] = {
+    "atac-correct": {
+        "bams": "file",
+        "genome": "file",
+        "peaks": "file",
+        "blacklist": "file",
+    },
+    "call-footprints": {"signal": "file", "signals": "file", "regions": "file"},
+    "match-motifs": {
+        "signals": "file",
+        "genome": "file",
+        "peaks": "file",
+        "peak_header": "file",
+        "motifs": "file",
+    },
+    "diff-footprints": {
+        "signals": "file",
+        "genome": "file",
+        "peaks": "file",
+        "peak_header": "file",
+        "motifs": "file",
+        "regions": "file",
+        "aggregate_signals": "file",
+        "sample_dirs": "dir",
+        "project_dir": "dir",
+    },
+    "normalize-bigwig": {
+        "bigwigs": "file",
+        "background": "file",
+        "sample_table": "file",
+        "chrom_sizes": "file",
+    },
+    "plot-aggregate": {
+        "TFBS": "file",
+        "tfbs": "file",
+        "signals": "file",
+        "regions": "file",
+        "whitelist": "file",
+        "blacklist": "file",
+        "manifest": "file",
+        "input_html": "file",
+        "sample_dirs": "dir",
+        "match_dir": "dir",
+    },
+    "review-multi-comparisons": {"inputs": "any"},
+    "bulk-footprinting": {
+        "sample_table": "file",
+        "comparison_table": "file",
+        "genome": "file",
+        "blacklist": "file",
+        "motifs": "file",
+    },
+    "discover-motifs": {
+        "fasta": "file",
+        "candidates": "file",
+        "genome": "file",
+        "known_motifs": "file",
+    },
+    "summarize-motifs": {"meme_txt": "file", "tomtom_tsv": "file"},
+    "pseudobulk-fragments": {"fragments": "file", "annotations": "file"},
+    "find-signature-fp": {
+        "fragments": "file",
+        "annotations": "file",
+        "h5ad": "file",
+        "tf_site_dir": "dir",
+        "all_motif_diff_dir": "dir",
+        "all_motif_results": "file",
+        "all_motif_score_table": "file",
+        "marker_score_table": "file",
+    },
+    "sc-footprinting": {
+        "fragments": "file",
+        "annotations": "file",
+        "h5ad": "file",
+        "genome": "file",
+        "peaks": "file",
+        "blacklist": "file",
+        "genome_sizes": "file",
+        "motifs": "file",
+    },
+}
+
+
+def _path_values(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    return [text] if text else []
+
+
+def _is_remote_path(value: str) -> bool:
+    return urlparse(value).scheme.lower() in {"http", "https", "ftp", "s3"}
+
+
+def _bam_index_exists(path: Path) -> bool:
+    candidates = [Path(str(path) + ".bai")]
+    if path.suffix.lower() == ".bam":
+        candidates.append(path.with_suffix(".bai"))
+    return any(candidate.is_file() for candidate in candidates)
+
+
+def _validate_gui_input_paths(tool: str, item: Mapping[str, Any], job_name: str) -> list[str]:
+    errors: list[str] = []
+    for field, expected in GUI_INPUT_PATH_FIELDS.get(tool, {}).items():
+        for value in _path_values(item.get(field)):
+            if _is_remote_path(value):
+                errors.append(
+                    f"{job_name}: '{field}' must be a local path; remote URLs are not supported: {value}"
+                )
+                continue
+            path = Path(value).expanduser()
+            valid = path.exists()
+            if expected == "file":
+                valid = path.is_file()
+            elif expected == "dir":
+                valid = path.is_dir()
+            if not valid:
+                label = "file or directory" if expected == "any" else expected
+                errors.append(f"{job_name}: '{field}' {label} does not exist: {value}")
+                continue
+            if field == "bams" and path.suffix.lower() == ".bam" and not _bam_index_exists(path):
+                errors.append(f"{job_name}: BAM index (.bai) is missing for '{field}': {value}")
+
+    if tool == "bulk-footprinting":
+        table_text = str(item.get("sample_table") or "").strip()
+        table_path = Path(table_text).expanduser() if table_text else None
+        if table_path is not None and table_path.is_file():
+            try:
+                from fp_tools.utils.project_layout import read_sample_table
+
+                samples = read_sample_table(table_path)
+            except (OSError, ValueError) as exc:
+                errors.append(f"{job_name}: invalid 'sample_table': {exc}")
+            else:
+                for sample in samples:
+                    for field, value in (("bam", sample.bam), ("peaks", sample.peaks)):
+                        path = Path(value).expanduser()
+                        if not value or not path.is_file():
+                            errors.append(
+                                f"{job_name}: sample {sample.sample!r} {field} file does not exist: {value or '<blank>'}"
+                            )
+                        elif field == "bam" and not _bam_index_exists(path):
+                            errors.append(
+                                f"{job_name}: sample {sample.sample!r} BAM index (.bai) is missing: {value}"
+                            )
+    return errors
+
+
+def validate_gui_config(config: Mapping[str, Any]) -> list[str]:
+    """Validate a config against the BAM-first GUI support boundary."""
+
+    normalized = normalize_config(config)
+    errors = validate_config(normalized)
+    normalized_raw_flags = {"--" + key.lstrip("-").replace("_", "-") for key in GUI_RAW_READ_KEYS}
+    for section in ("samples", "comparisons"):
+        for idx, item in enumerate(normalized[section], start=1):
+            tool = canonical_tool_name(str(item.get("tool", "")))
+            job_name = str(
+                item.get("sample_id")
+                or item.get("comparison_id")
+                or item.get("job_id")
+                or f"{tool.lower()}_{idx:03d}"
+            )
+            if tool == "prepare-atac":
+                errors.append(
+                    f"{job_name}: the GUI starts from BAM/BAI and peak BED files; "
+                    "run prepare-atac with the Linux CLI or Linux container first"
+                )
+                continue
+            if isinstance(item.get("extra_args"), str):
+                errors.append(f"{job_name}: 'extra_args' must be a YAML list, not a string")
+            if tool == "bulk-footprinting":
+                configured_raw_keys = [
+                    key
+                    for key in GUI_RAW_READ_KEYS
+                    if key in item and item.get(key) not in (None, "", False, [])
+                ]
+                extras = item.get("extra_args", []) or []
+                if isinstance(extras, str):
+                    extras = extras.split()
+                raw_extra_flags = [
+                    str(value).split("=", 1)[0]
+                    for value in extras
+                    if str(value).split("=", 1)[0] in normalized_raw_flags
+                ]
+                if configured_raw_keys or raw_extra_flags:
+                    errors.append(
+                        f"{job_name}: GUI bulk workflows require 'sample_table' with "
+                        "BAM/BAI and peak BED inputs; FASTQ preparation is Linux CLI/container only"
+                    )
+            for field, choices in GUI_ENUM_CHOICES.get(tool, {}).items():
+                value = item.get(field)
+                if value not in (None, "") and str(value) not in choices:
+                    errors.append(
+                        f"{job_name}: unsupported '{field}' value {value!r}; choose {', '.join(choices)}"
+                    )
+            if tool == "normalize-bigwig":
+                stat = str(item.get("stat") or "q90")
+                if stat not in {"median", "iqr"}:
+                    try:
+                        quantile = float(stat.removeprefix("q"))
+                    except ValueError:
+                        quantile = -1
+                    if not stat.startswith("q") or not 0 < quantile < 100:
+                        errors.append(
+                            f"{job_name}: unsupported 'stat' value {stat!r}; use median, iqr, or q0-q100"
+                        )
+            if tool == "summarize-motifs" and not any(
+                str(item.get(field) or "").strip() for field in ("meme_txt", "tomtom_tsv")
+            ):
+                errors.append(f"{job_name}: provide 'meme_txt' or 'tomtom_tsv'")
+            errors.extend(_validate_gui_input_paths(tool, item, job_name))
+    return list(dict.fromkeys(errors))
 
 
 def _key_to_flag(key: str) -> str:

--- a/src/fp_tools/platform_support.py
+++ b/src/fp_tools/platform_support.py
@@ -1,0 +1,26 @@
+"""Platform support boundaries shared by fp-tools command interfaces."""
+
+from __future__ import annotations
+
+import platform
+
+
+RAW_READ_LINUX_ONLY_MESSAGE = (
+    "FASTQ-to-BAM preparation is supported only by the Linux command line and "
+    "the Linux fp-tools container. Native macOS and Windows installations, "
+    "desktop applications, and every fp-tools GUI start from coordinate-sorted "
+    "BAM/BAI files plus matching peak BED files."
+)
+
+
+def supports_raw_read_preparation() -> bool:
+    """Return whether this process is running on a supported raw-read host."""
+
+    return platform.system() == "Linux"
+
+
+def require_raw_read_preparation_support() -> None:
+    """Raise a concise error when raw-read preparation is unavailable."""
+
+    if not supports_raw_read_preparation():
+        raise ValueError(RAW_READ_LINUX_ONLY_MESSAGE)

--- a/src/fp_tools/resources/gui_configs/__init__.py
+++ b/src/fp_tools/resources/gui_configs/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged BAM-first GUI example configurations."""

--- a/src/fp_tools/resources/gui_configs/atac_correct_batch.yml
+++ b/src/fp_tools/resources/gui_configs/atac_correct_batch.yml
@@ -1,0 +1,20 @@
+version: 1
+run_mode: batch
+samples:
+  - sample_id: atac_correct_batch_a
+    tool: atac-correct
+    bams:
+      - test_data/Bcell.bam
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks.bed
+    blacklist: test_data/blacklist.bed
+    outdir: examples/gui_demo_outputs/atac_correct_batch_a
+  - sample_id: atac_correct_batch_b
+    tool: atac-correct
+    bams:
+      - test_data/Bcell.bam
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks.bed
+    blacklist: test_data/blacklist.bed
+    outdir: examples/gui_demo_outputs/atac_correct_batch_b
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/atac_correct_single.yml
+++ b/src/fp_tools/resources/gui_configs/atac_correct_single.yml
@@ -1,0 +1,12 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: atacorrect_bcell
+    tool: atac-correct
+    bams:
+      - test_data/Bcell.bam
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks.bed
+    blacklist: test_data/blacklist.bed
+    outdir: examples/gui_demo_outputs/atac_correct_single
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/bulk_footprinting_bam.yml
+++ b/src/fp_tools/resources/gui_configs/bulk_footprinting_bam.yml
@@ -1,0 +1,15 @@
+version: 1
+run_mode: single
+defaults: {}
+samples:
+  - sample_id: bulk_footprinting_bam
+    tool: bulk-footprinting
+    sample_table: docs/demos/data/encode/encode_hepg2_k562_bams.tsv
+    comparison_table: docs/demos/data/encode/encode_hepg2_k562_comparisons.tsv
+    genome: hg38.fa.gz
+    blacklist: hg38.blacklist.bed
+    motif_db: jaspar2026_vertebrates
+    outdir: examples/gui_demo_outputs/bulk_footprinting
+    cores: 4
+    dry_run: true
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/call_footprints_batch.yml
+++ b/src/fp_tools/resources/gui_configs/call_footprints_batch.yml
@@ -1,0 +1,16 @@
+version: 1
+run_mode: batch
+samples:
+  - sample_id: call_footprints_bcell
+    tool: call-footprints
+    signal: test_data/Bcell_corrected.bw
+    regions: test_data/merged_peaks.bed
+    output: examples/gui_demo_outputs/call_call_footprints_batch/Bcell_footprints.bw
+    score: footprint
+  - sample_id: call_footprints_tcell
+    tool: call-footprints
+    signal: test_data/Tcell_corrected.bw
+    regions: test_data/merged_peaks.bed
+    output: examples/gui_demo_outputs/call_call_footprints_batch/Tcell_footprints.bw
+    score: footprint
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/call_footprints_single.yml
+++ b/src/fp_tools/resources/gui_configs/call_footprints_single.yml
@@ -1,0 +1,10 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: call_footprints_bcell
+    tool: call-footprints
+    signal: test_data/Bcell_corrected.bw
+    regions: test_data/merged_peaks.bed
+    output: examples/gui_demo_outputs/call_call_footprints_single/Bcell_footprints.bw
+    score: footprint
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/diff_footprints_batch_single.yml
+++ b/src/fp_tools/resources/gui_configs/diff_footprints_batch_single.yml
@@ -1,0 +1,28 @@
+version: 1
+run_mode: batch
+samples:
+  - sample_id: diff_call_footprints_single_bcell
+    tool: diff-footprints
+    motifs: test_data/motifs.jaspar
+    signals:
+      - test_data/Bcell_footprints.bw
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks_annotated.bed
+    peak_header: test_data/merged_peaks_annotated_header.txt
+    outdir: examples/gui_demo_outputs/diff_call_footprints_batch_single_bcell
+    cond_names:
+      - Bcell
+    skip_excel: true
+  - sample_id: diff_call_footprints_single_tcell
+    tool: diff-footprints
+    motifs: test_data/motifs.jaspar
+    signals:
+      - test_data/Tcell_day1_footprints.bw
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks_annotated.bed
+    peak_header: test_data/merged_peaks_annotated_header.txt
+    outdir: examples/gui_demo_outputs/diff_call_footprints_batch_single_tcell
+    cond_names:
+      - Tcell
+    skip_excel: true
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/diff_footprints_comparison_2v2.yml
+++ b/src/fp_tools/resources/gui_configs/diff_footprints_comparison_2v2.yml
@@ -1,0 +1,22 @@
+version: 1
+run_mode: batch
+samples: []
+comparisons:
+  - comparison_id: bcell_vs_tcell_demo
+    tool: diff-footprints
+    motifs: test_data/motifs.jaspar
+    signals:
+      - test_data/demo_Bcell_rep1_footprints.bw
+      - test_data/demo_Bcell_rep2_footprints.bw
+      - test_data/demo_Tcell_rep1_footprints.bw
+      - test_data/demo_Tcell_rep2_footprints.bw
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks_annotated.bed
+    peak_header: test_data/merged_peaks_annotated_header.txt
+    outdir: examples/gui_demo_outputs/diff_call_footprints_comparison_2v2
+    cond_names:
+      - Bcell
+      - Bcell
+      - Tcell
+      - Tcell
+    skip_excel: true

--- a/src/fp_tools/resources/gui_configs/diff_footprints_regions.yml
+++ b/src/fp_tools/resources/gui_configs/diff_footprints_regions.yml
@@ -1,0 +1,26 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: k562_ctcf_regions
+    tool: diff-footprints
+    comparison_axis: regions
+    signals:
+      - K562_rep1_footprints.bw
+      - K562_rep2_footprints.bw
+    sample_names:
+      - K562_rep1
+      - K562_rep2
+    cond_names:
+      - K562
+      - K562
+    regions:
+      - CTCF_bound.bed
+      - matched_control.bed
+    region_labels:
+      - CTCF_bound
+      - matched_control
+    region_strata_column: 4
+    genome: hg38.fa
+    motif_db: jaspar2026_vertebrates
+    outdir: region_set_comparison
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/diff_footprints_single.yml
+++ b/src/fp_tools/resources/gui_configs/diff_footprints_single.yml
@@ -1,0 +1,16 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: diff_call_footprints_single_bcell
+    tool: diff-footprints
+    motifs: test_data/motifs.jaspar
+    signals:
+      - test_data/Bcell_footprints.bw
+    genome: test_data/genome.fa.gz
+    peaks: test_data/merged_peaks_annotated.bed
+    peak_header: test_data/merged_peaks_annotated_header.txt
+    outdir: examples/gui_demo_outputs/diff_call_footprints_single
+    cond_names:
+      - Bcell
+    skip_excel: true
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/discover_motifs_single.yml
+++ b/src/fp_tools/resources/gui_configs/discover_motifs_single.yml
@@ -1,0 +1,11 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: motif_discovery_demo
+    tool: discover-motifs
+    candidates: test_data/merged_peaks.bed
+    genome: test_data/genome.fa.gz
+    outdir: examples/gui_demo_outputs/motif_discovery
+    method: streme
+    known_motif_db: jaspar2026_vertebrates
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/find_signature_fp.yml
+++ b/src/fp_tools/resources/gui_configs/find_signature_fp.yml
@@ -1,0 +1,13 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: signature_fp_run
+    tool: find-signature-fp
+    fragments: data/public/raw/10x_pbmc5k_scatac/atac_pbmc_5k_nextgem_fragments.tsv.gz
+    annotations: data/public/processed/pseudobulk_pbmc5k_scatac/pbmc5k_scprinter_broad_annotations.tsv
+    h5ad: data/public/processed/pseudobulk_pbmc5k_scatac/pbmc5k_scprinter_broad.h5ad
+    tf_site_dir: data/public/processed/pseudobulk_pbmc5k_scatac/footprint_demo/tf_sites
+    outdir: examples/gui_demo_outputs/signature_fp
+    markers: STAT6,FOSB,CEBPA,IRF8,RELA,ZNF683,NR4A1,SMAD3
+    summary_output_prefix: single_cell_footprinting
+    max_motifs: 25

--- a/src/fp_tools/resources/gui_configs/normalize_bigwig_single.yml
+++ b/src/fp_tools/resources/gui_configs/normalize_bigwig_single.yml
@@ -1,0 +1,14 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: normalize_bigwig_demo
+    tool: normalize-bigwig
+    bigwigs:
+      - test_data/Bcell_corrected.bw
+      - test_data/Tcell_corrected.bw
+    background: test_data/merged_peaks.bed
+    outdir: examples/gui_demo_outputs/normalize_bigwig
+    method: background-scale
+    stat: q95
+    target: median
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/plot_aggregate_batch.yml
+++ b/src/fp_tools/resources/gui_configs/plot_aggregate_batch.yml
@@ -1,0 +1,31 @@
+version: 1
+run_mode: batch
+samples:
+  - sample_id: plotaggregate_panel_a
+    tool: plot-aggregate
+    TFBS:
+      - examples/plotaggregate_tfbs_dir/BATF_all.bed
+      - examples/plotaggregate_tfbs_dir/IRF1_all.bed
+    signals:
+      - test_data/Bcell_corrected.bw
+      - test_data/Tcell_corrected.bw
+    output: examples/gui_demo_outputs/plot_aggregate_batch/panel_a.pdf
+    output_aggregated_scores: examples/gui_demo_outputs/plot_aggregate_batch/panel_a_scores.csv
+    output_aggregated_signals: examples/gui_demo_outputs/plot_aggregate_batch/panel_a_signals.csv
+    grid: 2x2
+  - sample_id: plotaggregate_panel_b
+    tool: plot-aggregate
+    TFBS:
+      - examples/plotaggregate_tfbs_grid/CTCF_Bcell_bound.bed
+      - examples/plotaggregate_tfbs_grid/ETS1_Bcell_bound.bed
+      - examples/plotaggregate_tfbs_grid/GATA3_Bcell_bound.bed
+      - examples/plotaggregate_tfbs_grid/IRF1_Bcell_bound.bed
+      - examples/plotaggregate_tfbs_grid/RUNX1_Bcell_bound.bed
+    signals:
+      - test_data/Bcell_corrected.bw
+      - test_data/Tcell_corrected.bw
+    output: examples/gui_demo_outputs/plot_aggregate_batch/panel_b.pdf
+    output_aggregated_scores: examples/gui_demo_outputs/plot_aggregate_batch/panel_b_scores.csv
+    output_aggregated_signals: examples/gui_demo_outputs/plot_aggregate_batch/panel_b_signals.csv
+    grid: 2x5
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/plot_aggregate_from_html.yml
+++ b/src/fp_tools/resources/gui_configs/plot_aggregate_from_html.yml
@@ -1,0 +1,11 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: plot_aggregate_html_from_html
+    tool: plot-aggregate
+    format: html
+    input_html:
+      - examples/gui_demo_outputs/diff_call_footprints_comparison_2v2/diff_call_footprints_Bcell_Tcell.html
+    output: examples/gui_demo_outputs/plot_aggregate_batch_browser.html
+    default_layout: 2x2
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/plot_aggregate_single.yml
+++ b/src/fp_tools/resources/gui_configs/plot_aggregate_single.yml
@@ -1,0 +1,16 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: plot_aggregate_single
+    tool: plot-aggregate
+    TFBS:
+      - examples/plotaggregate_tfbs_dir/BATF_all.bed
+      - examples/plotaggregate_tfbs_dir/IRF1_all.bed
+    signals:
+      - test_data/Bcell_corrected.bw
+      - test_data/Tcell_corrected.bw
+    output: examples/gui_demo_outputs/plot_aggregate_single/plot_aggregate.pdf
+    output_aggregated_scores: examples/gui_demo_outputs/plot_aggregate_single/plotaggregate_scores.csv
+    output_aggregated_signals: examples/gui_demo_outputs/plot_aggregate_single/plotaggregate_signals.csv
+    grid: 2x2
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/pseudobulk_fragments_single.yml
+++ b/src/fp_tools/resources/gui_configs/pseudobulk_fragments_single.yml
@@ -1,0 +1,13 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: pseudobulk_fragments_demo
+    tool: pseudobulk-fragments
+    fragments: data/public/raw/10x_pbmc5k_scatac/atac_pbmc_5k_nextgem_fragments.tsv.gz
+    annotations: data/public/processed/pseudobulk_pbmc5k_scatac/pbmc5k_scprinter_broad_annotations.tsv
+    group_by: cell_type
+    outdir: examples/gui_demo_outputs/pseudobulk_fragments
+    min_cells: 1
+    min_fragments: 1
+    index_output: true
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/sc_footprinting_dry_run.yml
+++ b/src/fp_tools/resources/gui_configs/sc_footprinting_dry_run.yml
@@ -1,0 +1,16 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: sc_footprinting_plan
+    tool: sc-footprinting
+    fragments: data/public/raw/10x_pbmc5k_scatac/atac_pbmc_5k_nextgem_fragments.tsv.gz
+    annotations: data/public/processed/pseudobulk_pbmc5k_scatac/pbmc5k_scprinter_broad_annotations.tsv
+    h5ad: data/public/processed/pseudobulk_pbmc5k_scatac/pbmc5k_scprinter_broad.h5ad
+    group_by: cell_type
+    outdir: examples/gui_demo_outputs/sc_footprinting
+    genome_sizes: data/public/processed/pseudobulk_pbmc5k_scatac/hg38.chrom.sizes
+    genome: data/public/raw/genome/hg38.fa
+    peaks: data/public/raw/10x_pbmc5k_scatac/atac_pbmc_5k_snatac2_selected_bins.demo.bed
+    motif_db: jaspar2026_vertebrates
+    dry_run: true
+comparisons: []

--- a/src/fp_tools/resources/gui_configs/summarize_motifs_single.yml
+++ b/src/fp_tools/resources/gui_configs/summarize_motifs_single.yml
@@ -1,0 +1,9 @@
+version: 1
+run_mode: single
+samples:
+  - sample_id: motif_summary_demo
+    tool: summarize-motifs
+    out_tsv: examples/gui_demo_outputs/motif_summary/motif_summary.tsv
+    out_html: examples/gui_demo_outputs/motif_summary/motif_summary.html
+    title: fp-tools motif summary
+comparisons: []

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc6",
-  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc6",
+  "runtime_version": "0.2.0rc7",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc7",
   "components": {
     "core": {
       "commands": [
@@ -37,29 +37,23 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-linux-x86_64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc7-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc7-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-linux-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-linux-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-linux-arm64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc7-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc7-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-macos-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-macos-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-macos-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc6-macos-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc6-macos-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc6-macos-arm64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "core": {"filename": "fp-tools-runtime-wsl-core-0.2.0rc6-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-wsl-core-0.2.0rc6-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-wsl-core-0.2.0rc6-linux-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc7-linux-x86_64.tar.gz"}
     }
   }
 }

--- a/src/fp_tools/tools/bulk_footprinting.py
+++ b/src/fp_tools/tools/bulk_footprinting.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from fp_tools.platform_support import require_raw_read_preparation_support
 from fp_tools.runtime import RuntimeProvisionError, add_runtime_argument, prepare_command_runtime
 from fp_tools.utils.project_layout import (
     analysis_peaks_path,
@@ -316,7 +317,10 @@ def build_parser() -> argparse.ArgumentParser:
     source.add_argument("--sample-table", help="TSV with sample, condition, BAM, and peak BED columns.")
     source.add_argument(
         "--reads-table",
-        help="TSV/CSV with local FASTQ paths or public run accessions; runs preparation before footprinting.",
+        help=(
+            "Linux CLI/container only: TSV/CSV with local FASTQ paths or public run "
+            "accessions; runs preparation before footprinting."
+        ),
     )
     parser.add_argument("--comparison-table", required=True, help="TSV with comparison, cond1, and cond2 columns.")
     parser.add_argument("--genome", required=True, help="Reference FASTA for aligned input, or hg38/mm10/custom label for raw reads.")
@@ -346,13 +350,64 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _require_input_file(value: str | None, flag: str) -> None:
+    if not value:
+        return
+    path = Path(value).expanduser()
+    if not path.is_file():
+        raise ValueError(f"{flag} file does not exist: {value}")
+
+
+def _preflight_input_paths(args: argparse.Namespace) -> None:
+    """Reject missing workflow inputs before runtime provisioning or writes."""
+
+    _require_input_file(args.reads_table or args.sample_table, "--reads-table" if args.reads_table else "--sample-table")
+    _require_input_file(args.comparison_table, "--comparison-table")
+    if args.reads_table:
+        for value, flag in (
+            (args.config, "--config"),
+            (args.fasta, "--fasta"),
+            (args.blacklist, "--blacklist"),
+            (args.tss, "--tss"),
+        ):
+            _require_input_file(value, flag)
+    else:
+        _require_input_file(args.genome, "--genome")
+        _require_input_file(args.blacklist, "--blacklist")
+        for motif in args.motifs or []:
+            _require_input_file(motif, "--motifs")
+
+
 def main(argv: list[str] | None = None) -> int:
     raw_args = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
     args = parser.parse_args(raw_args)
     if args.resume and args.force:
         parser.error("--resume and --force are mutually exclusive")
+    if args.reads_table:
+        try:
+            require_raw_read_preparation_support()
+        except ValueError as exc:
+            parser.error(str(exc))
+    elif any(
+        argument.split("=", 1)[0]
+        in {
+            "--config",
+            "--profile",
+            "--reference-dir",
+            "--fasta",
+            "--bowtie2-index",
+            "--tss",
+            "--macs-genome-size",
+            "--max-parallel-samples",
+            "--memory-gb",
+            "--keep-intermediates",
+        }
+        for argument in raw_args
+    ):
+        parser.error("raw-read preparation options require --reads-table")
     try:
+        _preflight_input_paths(args)
         if args.reads_table and not args.dry_run:
             delegated = prepare_command_runtime(
                 "bulk-footprinting",

--- a/src/fp_tools/tools/prepare_atac.py
+++ b/src/fp_tools/tools/prepare_atac.py
@@ -1,4 +1,4 @@
-"""Prepare raw ATAC-seq reads as stable inputs for fp-tools.
+"""Prepare raw ATAC-seq reads as stable inputs for fp-tools on Linux.
 
 The module intentionally remains an orchestration layer.  It validates sample
 metadata, resolves public FASTQs, invokes established command-line tools, and
@@ -33,9 +33,10 @@ from fp_tools.runtime import (
     add_runtime_argument,
     prepare_command_runtime,
 )
+from fp_tools.platform_support import require_raw_read_preparation_support
 try:
     import pysam
-except ImportError:  # Raw-read preparation is documented through WSL on Windows.
+except ImportError:  # Non-Linux wheels retain the help/error entry point only.
     pysam = None
 import yaml
 
@@ -1573,11 +1574,7 @@ def _available_memory_gb() -> float:
 
 
 def run_preprocessing(args: argparse.Namespace) -> int:
-    if os.name == "nt":
-        raise SystemExit(
-            "prepare-atac requires Unix bioinformatics executables. On Windows, run it in WSL; "
-            "the downstream fp-tools commands and GUI run natively."
-        )
+    require_raw_read_preparation_support()
     overrides: dict[str, Any] = {"profile": args.profile} if args.profile else {}
     resource_overrides = {
         key: value
@@ -1836,6 +1833,10 @@ def main(argv: list[str] | None = None) -> int:
     raw_args = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
     args = parser.parse_args(raw_args)
+    try:
+        require_raw_read_preparation_support()
+    except ValueError as exc:
+        parser.error(str(exc))
     if args.write_default_config:
         print(write_default_config(args.write_default_config, args.profile or "modern"))
         return 0

--- a/src/fp_tools/tools/score_bigwig.py
+++ b/src/fp_tools/tools/score_bigwig.py
@@ -13,10 +13,12 @@ import sys
 import argparse
 import copy
 import bisect
+import queue
 import numpy as np
 from fp_tools.utils import bigwig as pyBigWig
 import multiprocessing as mp
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 
 # Internal functions and classes (fp_tools namespace)
@@ -378,8 +380,13 @@ def _run_scorebigwig_single(args):
     logger.arguments_overview(parser, args)
     logger.output_files([args.output, getattr(args, "output_multiscale_npz", None), getattr(args, "output_bed", None)])
 
+    # A one-core run stays entirely in-process.  This is materially faster for
+    # frozen desktop applications on Windows because spawning each worker
+    # would otherwise unpack the full one-file executable again.
+    args.cores = check_cores(args.cores, logger)
     logger.debug("Setting up listener for log")
-    logger.start_logger_queue()
+    if args.cores > 1:
+        logger.start_logger_queue()
     args.log_q = logger.queue
 
     # ------------------------------------------------------------------------- #
@@ -442,9 +449,41 @@ def _run_scorebigwig_single(args):
     logger.info("Calculating footprints in regions...")
     regions_chunks = regions.chunks(args.split)
 
-    args.cores = check_cores(args.cores, logger)
     logger.debug(f"Worker cores: {args.cores}")
     logger.debug("Writer cores: 1")
+
+    if args.cores == 1:
+        writer_queue = queue.Queue()
+        writer_args = copy.copy(args)
+        worker_args = copy.copy(args)
+        worker_args.writer_qs = {"scores": writer_queue}
+        results = []
+        with ThreadPoolExecutor(max_workers=1) as writer_executor:
+            writer_future = writer_executor.submit(
+                bigwig_writer,
+                writer_queue,
+                {"scores": args.output},
+                header,
+                regions,
+                writer_args,
+            )
+            try:
+                for chunk in regions_chunks:
+                    results.append(calculate_scores(chunk, copy.copy(worker_args)))
+            finally:
+                writer_queue.put((None, None, None))
+            writer_future.result()
+
+        if getattr(args, "output_multiscale_npz", None):
+            records = [record for chunk_records in results for record in chunk_records]
+            records.sort(key=lambda item: (reference_chroms.index(item[0][0]), item[0][1]))
+            write_multiscale_npz(args.output_multiscale_npz, records, args.scales, args.multiscale_summary)
+
+        _validate_bigwig_output(args.output, logger)
+        if getattr(args, "output_bed", None):
+            _write_candidate_bed(args.output, regions, args.output_bed, args, chrom_info, logger)
+        logger.end()
+        return
 
     manager = mp.Manager()
     pool = None

--- a/src/fp_tools/tools/score_bigwig.py
+++ b/src/fp_tools/tools/score_bigwig.py
@@ -464,7 +464,7 @@ def _run_scorebigwig_single(args):
                 writer_queue,
                 {"scores": args.output},
                 header,
-                regions,
+                copy.deepcopy(regions),
                 writer_args,
             )
             try:

--- a/src/fp_tools/utils/bigwig.py
+++ b/src/fp_tools/utils/bigwig.py
@@ -9,6 +9,7 @@ not need platform checks.
 from __future__ import annotations
 
 import math
+import ntpath
 import os
 import queue
 import threading
@@ -35,6 +36,25 @@ def backend_name() -> str:
     """Return the selected bigWig backend name."""
 
     return "pyBigWig" if _pybigwig is not None else "pybigtools"
+
+
+def _pybigtools_write_path(path: str | os.PathLike[str]) -> str:
+    """Return a local path that pybigtools will not parse as a URL.
+
+    pybigtools checks strings with Rust's URL parser before opening an output.
+    A normal absolute Windows path (``C:\\...``) is consequently mistaken for
+    a URL with scheme ``c``.  The equivalent Windows extended-length form is
+    still a valid local filesystem path and is unambiguously not a URL.
+    """
+
+    if os.name != "nt":
+        return os.path.abspath(os.fspath(path))
+    resolved = ntpath.abspath(os.fspath(path))
+    if resolved.startswith("\\\\?\\"):
+        return resolved
+    if resolved.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + resolved.lstrip("\\")
+    return "\\\\?\\" + resolved
 
 
 def open(path: str | os.PathLike[str], mode: str = "r"):  # noqa: A001 - API compatibility
@@ -151,7 +171,7 @@ class _StreamingBigWigWriter:
 
     def _write(self) -> None:
         try:
-            writer = _pybigtools.open(str(self.path), "w")
+            writer = _pybigtools.open(_pybigtools_write_path(self.path), "w")
             writer.write(self._header, self._records())
         except Exception as exc:  # surfaced in close/addEntries
             self._error = exc

--- a/tests/test_cli_and_config_smoke.py
+++ b/tests/test_cli_and_config_smoke.py
@@ -6,10 +6,18 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from fp_tools.cli_batch import run_config_file
-from fp_tools.gui_config import build_cli_command, expand_jobs, load_yaml_config, normalize_config, validate_config
+from fp_tools.gui_config import (
+    build_cli_command,
+    expand_jobs,
+    load_yaml_config,
+    normalize_config,
+    validate_config,
+    validate_gui_config,
+)
 from fp_tools.parsers import add_aggregate_arguments, add_atacorrect_arguments, add_diff_footprints_arguments, add_scorebigwig_arguments
 from fp_tools.tools import diff_footprints
 from fp_tools.tools.diff_footprints import _prepare_condition_metadata
@@ -36,6 +44,89 @@ class CliAndConfigSmokeTest(unittest.TestCase):
         self.assertEqual(validate_config(raw), [])
         self.assertEqual(validate_config(aligned), [])
         self.assertTrue(any("exactly one" in value for value in validate_config(both)))
+
+    def test_gui_accepts_bam_bulk_config_and_rejects_raw_reads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bam = root / "sample.bam"
+            bai = root / "sample.bam.bai"
+            peaks = root / "peaks.bed"
+            genome = root / "genome.fa"
+            comparisons = root / "comparisons.tsv"
+            samples = root / "samples.tsv"
+            for path in (bam, bai, peaks, genome):
+                path.write_bytes(b"fixture")
+            comparisons.write_text("comparison\tcond1\tcond2\n", encoding="utf-8")
+            samples.write_text(
+                f"sample\tcondition\tbam\tpeaks\nsample\tA\t{bam}\t{peaks}\n",
+                encoding="utf-8",
+            )
+            base = {
+                "tool": "bulk-footprinting",
+                "comparison_table": str(comparisons),
+                "genome": str(genome),
+                "outdir": str(root / "results"),
+            }
+            aligned = {"samples": [{**base, "sample_table": str(samples)}], "comparisons": []}
+            raw = {"samples": [{**base, "reads_table": "reads.tsv"}], "comparisons": []}
+            raw_extra = {
+                "samples": [
+                    {**base, "sample_table": str(samples), "extra_args": ["--reads-table=reads.tsv"]}
+                ],
+                "comparisons": [],
+            }
+            self.assertEqual(validate_gui_config(aligned), [])
+            self.assertTrue(any("GUI bulk workflows" in error for error in validate_gui_config(raw)))
+            self.assertTrue(any("GUI bulk workflows" in error for error in validate_gui_config(raw_extra)))
+
+    def test_gui_rejects_prepare_atac_even_on_linux(self):
+        config = {
+            "samples": [
+                {
+                    "tool": "prepare-atac",
+                    "samples": "reads.tsv",
+                    "genome": "hg38",
+                    "outdir": "project",
+                }
+            ],
+            "comparisons": [],
+        }
+        self.assertTrue(any("GUI starts from BAM/BAI" in error for error in validate_gui_config(config)))
+
+    def test_gui_rejects_invalid_enum_values_loaded_from_yaml(self):
+        config = {
+            "samples": [
+                {
+                    "tool": "bulk-footprinting",
+                    "sample_table": "missing.tsv",
+                    "comparison_table": "missing-comparisons.tsv",
+                    "genome": "missing.fa",
+                    "outdir": "results",
+                    "review_format": "not-a-format",
+                    "plot_aggregate": "not-a-mode",
+                    "normalization": "not-a-normalization",
+                }
+            ],
+            "comparisons": [],
+        }
+        errors = validate_gui_config(config)
+        self.assertTrue(any("unsupported 'review_format'" in error for error in errors))
+        self.assertTrue(any("unsupported 'plot_aggregate'" in error for error in errors))
+        self.assertTrue(any("unsupported 'normalization'" in error for error in errors))
+
+    def test_gui_requires_motif_summary_input(self):
+        config = {
+            "samples": [
+                {
+                    "tool": "summarize-motifs",
+                    "meme_txt": "",
+                    "tomtom_tsv": "",
+                    "out_tsv": "summary.tsv",
+                }
+            ],
+            "comparisons": [],
+        }
+        self.assertTrue(any("provide 'meme_txt' or 'tomtom_tsv'" in error for error in validate_gui_config(config)))
 
     def test_region_comparison_yaml_does_not_require_peaks(self):
         config = {

--- a/tests/test_cross_platform_io.py
+++ b/tests/test_cross_platform_io.py
@@ -8,6 +8,7 @@ import subprocess
 import os
 import sys
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 
@@ -22,6 +23,21 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class CrossPlatformIoTests(unittest.TestCase):
+    def test_pybigtools_windows_write_paths_are_not_url_like(self):
+        with mock.patch.object(bigwig.os, "name", "nt"):
+            self.assertEqual(
+                bigwig._pybigtools_write_path(r"C:\Users\runner\result.bw"),
+                r"\\?\C:\Users\runner\result.bw",
+            )
+            self.assertEqual(
+                bigwig._pybigtools_write_path(r"\\server\share\result.bw"),
+                r"\\?\UNC\server\share\result.bw",
+            )
+            self.assertEqual(
+                bigwig._pybigtools_write_path(r"\\?\C:\data\result.bw"),
+                r"\\?\C:\data\result.bw",
+            )
+
     def test_logger_listener_does_not_require_pickling_logger(self):
         logger = FpToolsLogger("portable-test", level=0)
         logger.start_logger_queue()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -169,7 +169,6 @@ class DocsEntryPointContractTest(unittest.TestCase):
 
     def test_core_command_footer_is_a_closed_sequence(self):
         sequence = [
-            "prepare-atac",
             "atac-correct",
             "call-footprints",
             "match-motifs",
@@ -304,6 +303,16 @@ class DocsEntryPointContractTest(unittest.TestCase):
             "not a reproduction of the pair-specific demo",
         ):
             self.assertNotIn(unnecessary_detail, guide)
+
+    def test_full_page_demo_links_open_new_tabs(self):
+        for relative in (
+            "get-started/output-examples/bulk-atac-seq.md",
+            "reports.md",
+            "gui.md",
+        ):
+            content = (ROOT / "docs" / relative).read_text(encoding="utf-8")
+            self.assertIn('target="_blank"', content, relative)
+            self.assertIn('rel="noopener noreferrer"', content, relative)
 
     def test_command_guides_use_precise_signal_names_and_file_patterns(self):
         command_dir = ROOT / "docs" / "get-started" / "commands"

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -5,6 +5,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from fp_tools.command_registry import COMMAND_TARGETS, dispatch_command
+from fp_tools.desktop import INTERNAL_LIST_EXAMPLES_FLAG, main as desktop_main
+from fp_tools.gui_app import (
+    GENERIC_TOOL_DEFAULTS,
+    _all_example_files,
+    _format_extra_args,
+    _parse_extra_args,
+)
 from fp_tools.cli_gui import _access_urls, _startup_messages
 from fp_tools.utils.subprocess_commands import (
     fp_tools_subprocess_command,
@@ -29,9 +36,8 @@ class GuiLauncherTests(unittest.TestCase):
             ["http://127.0.0.1:8891", "http://SERVER_IP:8891"],
         )
 
-    def test_desktop_registry_covers_current_public_commands(self):
+    def test_desktop_registry_covers_bam_first_commands(self):
         expected = {
-            "prepare-atac",
             "bulk-footprinting",
             "atac-correct",
             "call-footprints",
@@ -50,6 +56,7 @@ class GuiLauncherTests(unittest.TestCase):
             "sc-footprinting",
         }
         self.assertTrue(expected.issubset(COMMAND_TARGETS))
+        self.assertNotIn("prepare-atac", COMMAND_TARGETS)
 
     def test_frozen_child_command_routes_through_desktop_executable(self):
         with patch("fp_tools.utils.subprocess_commands.is_frozen", return_value=True):
@@ -76,6 +83,42 @@ class GuiLauncherTests(unittest.TestCase):
             dispatch_command("summarize-motifs", ["--help"])
         self.assertEqual(raised.exception.code, 0)
         self.assertIs(sys.argv, previous)
+
+    def test_desktop_lists_packaged_bam_first_examples(self):
+        with patch("builtins.print") as printer:
+            self.assertEqual(desktop_main([INTERNAL_LIST_EXAMPLES_FLAG]), 0)
+        names = {str(call.args[0]) for call in printer.call_args_list}
+        self.assertIn("bulk_footprinting_bam.yml", names)
+
+    def test_packaged_examples_are_available_outside_the_source_directory(self):
+        packaged = {path.name: path.read_text(encoding="utf-8") for path in _all_example_files()}
+        names = set(packaged)
+        self.assertIn("bulk_footprinting_bam.yml", names)
+        self.assertIn("call_footprints_single.yml", names)
+        source_dir = Path(__file__).resolve().parents[1] / "examples" / "gui_configs"
+        for source in source_dir.glob("*.yml"):
+            self.assertEqual(packaged[source.name], source.read_text(encoding="utf-8"))
+
+    def test_generic_forms_keep_supported_blank_fields(self):
+        self.assertIn("sample_table", GENERIC_TOOL_DEFAULTS["bulk-footprinting"])
+        self.assertNotIn("reads_table", GENERIC_TOOL_DEFAULTS["bulk-footprinting"])
+        self.assertTrue(
+            {"meme_txt", "tomtom_tsv"}.issubset(GENERIC_TOOL_DEFAULTS["summarize-motifs"])
+        )
+        self.assertTrue(
+            {"labels", "output_dir", "output_html"}.issubset(
+                GENERIC_TOOL_DEFAULTS["review-multi-comparisons"]
+            )
+        )
+        self.assertTrue(
+            {"candidates", "fasta", "script", "execute"}.issubset(
+                GENERIC_TOOL_DEFAULTS["discover-motifs"]
+            )
+        )
+
+    def test_extra_args_round_trip_windows_path_with_spaces(self):
+        arguments = ["--meme-txt", r"C:\Research data\meme.txt", "--title", "B cell motifs"]
+        self.assertEqual(_parse_extra_args(_format_extra_args(arguments)), arguments)
 
 
 if __name__ == "__main__":

--- a/tests/test_platform_scope.py
+++ b/tests/test_platform_scope.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from fp_tools.tools import bulk_footprinting, prepare_atac
+
+
+class PlatformScopeTest(unittest.TestCase):
+    def test_prepare_atac_rejects_non_linux_before_writes_or_runtime_setup(self):
+        for host in ("Darwin", "Windows"):
+            with self.subTest(host=host), tempfile.TemporaryDirectory() as tmpdir:
+                output = Path(tmpdir) / "project"
+                config = Path(tmpdir) / "defaults.yml"
+                with mock.patch(
+                    "fp_tools.platform_support.platform.system", return_value=host
+                ), mock.patch.object(prepare_atac, "prepare_command_runtime") as runtime:
+                    with self.assertRaises(SystemExit) as raised:
+                        prepare_atac.main(["--write-default-config", str(config)])
+                self.assertEqual(raised.exception.code, 2)
+                self.assertFalse(output.exists())
+                self.assertFalse(config.exists())
+                runtime.assert_not_called()
+
+    def test_prepare_atac_help_remains_available_on_non_linux(self):
+        with mock.patch(
+            "fp_tools.platform_support.platform.system", return_value="Darwin"
+        ), self.assertRaises(SystemExit) as raised:
+            prepare_atac.main(["--help"])
+        self.assertEqual(raised.exception.code, 0)
+
+    def test_bulk_raw_mode_rejects_non_linux_for_every_runtime(self):
+        for host in ("Darwin", "Windows"):
+            for runtime_mode in ("auto", "managed", "system", "container"):
+                with self.subTest(host=host, runtime=runtime_mode), tempfile.TemporaryDirectory() as tmpdir:
+                    output = Path(tmpdir) / "project"
+                    with mock.patch(
+                        "fp_tools.platform_support.platform.system", return_value=host
+                    ), mock.patch.object(
+                        bulk_footprinting, "prepare_command_runtime"
+                    ) as runtime:
+                        with self.assertRaises(SystemExit) as raised:
+                            bulk_footprinting.main(
+                                [
+                                    "--reads-table",
+                                    "reads.tsv",
+                                    "--comparison-table",
+                                    "comparisons.tsv",
+                                    "--genome",
+                                    "hg38",
+                                    "--outdir",
+                                    str(output),
+                                    "--runtime",
+                                    runtime_mode,
+                                ]
+                            )
+                    self.assertEqual(raised.exception.code, 2)
+                    self.assertFalse(output.exists())
+                    runtime.assert_not_called()
+
+    def test_linux_bulk_raw_mode_reaches_the_existing_workflow(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            reads = root / "reads.tsv"
+            comparisons = root / "comparisons.tsv"
+            reads.write_text("sample\tcondition\tfastq_1\n", encoding="utf-8")
+            comparisons.write_text("comparison\tcond1\tcond2\n", encoding="utf-8")
+            with mock.patch(
+                "fp_tools.platform_support.platform.system", return_value="Linux"
+            ), mock.patch.object(
+                bulk_footprinting, "run_bulk_footprinting", return_value=0
+            ) as run:
+                result = bulk_footprinting.main(
+                    [
+                        "--reads-table",
+                        str(reads),
+                        "--comparison-table",
+                        str(comparisons),
+                        "--genome",
+                        "hg38",
+                        "--outdir",
+                        str(root / "project"),
+                        "--dry-run",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        run.assert_called_once()
+
+    def test_bam_mode_rejects_raw_only_options(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "project"
+            with self.assertRaises(SystemExit) as raised:
+                bulk_footprinting.main(
+                    [
+                        "--sample-table",
+                        "samples.tsv",
+                        "--comparison-table",
+                        "comparisons.tsv",
+                        "--genome",
+                        "genome.fa.gz",
+                        "--outdir",
+                        str(output),
+                        "--profile",
+                        "modern",
+                    ]
+                )
+            self.assertEqual(raised.exception.code, 2)
+            self.assertFalse(output.exists())
+
+    def test_missing_raw_input_is_rejected_before_runtime_setup(self):
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.object(
+            bulk_footprinting, "prepare_command_runtime"
+        ) as runtime:
+            root = Path(tmpdir)
+            comparisons = root / "comparisons.tsv"
+            comparisons.write_text("comparison\tcond1\tcond2\n", encoding="utf-8")
+            with self.assertRaises(SystemExit) as raised:
+                bulk_footprinting.main(
+                    [
+                        "--reads-table",
+                        str(root / "missing.tsv"),
+                        "--comparison-table",
+                        str(comparisons),
+                        "--genome",
+                        "hg38",
+                        "--outdir",
+                        str(root / "project"),
+                    ]
+                )
+            self.assertEqual(raised.exception.code, 2)
+            runtime.assert_not_called()
+            self.assertFalse((root / "project").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -136,6 +136,13 @@ class RuntimeManagerTest(unittest.TestCase):
         resolver.assert_not_called()
         self.assertEqual(rows[0]["installed"], "no")
 
+    def test_non_linux_runtime_manifest_exposes_only_meme(self):
+        manifest = runtime.load_runtime_manifest()
+        for target in ("macos-x86_64", "macos-arm64", "windows-x86_64"):
+            self.assertEqual(set(manifest["artifacts"][target]), {"meme"})
+        for target in ("linux-x86_64", "linux-arm64"):
+            self.assertEqual(set(manifest["artifacts"][target]), {"core", "meme", "homer"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make every GUI and native desktop workflow start from BAM/BAI plus peak BED inputs
- retain FASTQ preparation only for the Linux CLI and Linux container
- package GUI examples and harden validation, enum controls, extra arguments, and preflight checks
- fix frozen Cython/bamnostic collection, multiprocessing startup, and responsive run cards
- narrow non-Linux managed runtimes to MEME and prepare the 0.2.0rc7 prerelease

## Validation
- 400 tests collected; all test modules passed (one existing skip)
- strict MkDocs build and 32-page browser audit passed
- frozen executable command, compiled-kernel, multiprocessing, example-resource, startup, and responsive audits passed
- wheel/sdist, twine, fresh-wheel, and console-script checks passed
- MEME-only WSL helper image built; STREME, discover-motifs, and pip checks passed

Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38