### PR TITLE
Disable invalid GUI runs and prepare rc8

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_version:
-        description: Existing package version to rebuild, for example 0.2.0rc7
+        description: Existing package version to rebuild, for example 0.2.0rc8
         required: false
         type: string
   push:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_version:
-        description: Existing package version to republish, for example 0.2.0rc7
+        description: Existing package version to republish, for example 0.2.0rc8
         required: false
         type: string
   push:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc7
+version: 0.2.0rc8
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -19,8 +19,8 @@ starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 Download the app for your computer, then open it. The GUI starts in your
 browser.
 
-[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc7/fp-tools-gui-windows-x64.exe){ .md-button }
-[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc7/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
+[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc8/fp-tools-gui-windows-x64.exe){ .md-button }
+[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc8/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
 The preview apps are unsigned. Windows may ask you to confirm the download. On
 macOS, Control-click the app and choose **Open** the first time.

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc7
+#      python -m pip install fp-tools-bio==0.2.0rc8
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc7}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc8}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc7</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc8</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc7"
+version = "0.2.0rc8"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -147,7 +147,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc7"
+version = "0.2.0rc8"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/scripts/audit_desktop_gui.py
+++ b/scripts/audit_desktop_gui.py
@@ -62,6 +62,34 @@ def _stop(process: subprocess.Popen[str]) -> None:
         process.wait(timeout=20)
 
 
+def _write_valid_bulk_fixture(root: Path) -> tuple[Path, Path, Path]:
+    """Create existence-only inputs for the GUI validation state transition."""
+
+    fixture = root / "valid-bulk-inputs"
+    fixture.mkdir()
+    genome = fixture / "genome.fa"
+    peaks = fixture / "peaks.bed"
+    for path in (genome, peaks):
+        path.write_text("fixture\n", encoding="utf-8")
+
+    sample_rows = ["sample\tcondition\tbam\tpeaks"]
+    for sample, condition in (("sample_a", "A"), ("sample_b", "B")):
+        bam = fixture / f"{sample}.bam"
+        bai = fixture / f"{sample}.bam.bai"
+        bam.write_bytes(b"fixture")
+        bai.write_bytes(b"fixture")
+        sample_rows.append(f"{sample}\t{condition}\t{bam}\t{peaks}")
+
+    samples = fixture / "samples.tsv"
+    samples.write_text("\n".join(sample_rows) + "\n", encoding="utf-8")
+    comparisons = fixture / "comparisons.tsv"
+    comparisons.write_text(
+        "comparison\tcond1\tcond2\nA_vs_B\tA\tB\n",
+        encoding="utf-8",
+    )
+    return samples, comparisons, genome
+
+
 def _audit_page(
     browser,
     base_url: str,
@@ -126,12 +154,20 @@ def main() -> int:
     port = _free_port()
     base_url = f"http://127.0.0.1:{port}"
     with tempfile.TemporaryDirectory(prefix="fp-tools-desktop-browser-") as workdir:
+        workdir_path = Path(workdir)
+        run_dir = workdir_path / "runs"
+        runtime_cache = workdir_path / "runtime-cache"
         process = subprocess.Popen(
-            [str(executable), "--no-browser", "--port", str(port), "--run-dir", str(Path(workdir) / "runs")],
+            [str(executable), "--no-browser", "--port", str(port), "--run-dir", str(run_dir)],
             cwd=workdir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            env={**os.environ, "STREAMLIT_BROWSER_GATHER_USAGE_STATS": "false"},
+            env={
+                **os.environ,
+                "FP_TOOLS_RUNTIME_CACHE": str(runtime_cache),
+                "LOCALAPPDATA": str(workdir_path / "local-app-data"),
+                "STREAMLIT_BROWSER_GATHER_USAGE_STATS": "false",
+            },
             start_new_session=os.name != "nt",
         )
         try:
@@ -166,8 +202,24 @@ def main() -> int:
                     page.get_by_text("Example YAML", exact=True).wait_for(timeout=30_000)
                     page.get_by_role("button", name="Load example", exact=True).wait_for(timeout=30_000)
                     page.get_by_text("Config needs fixes before launch.", exact=True).wait_for(timeout=30_000)
+                    start_button = page.get_by_role("button", name="Start run", exact=True)
+                    if not start_button.is_disabled():
+                        raise RuntimeError("Start run remains enabled for an invalid bulk configuration")
+                    if run_dir.exists() and any(run_dir.iterdir()):
+                        raise RuntimeError("Invalid bulk configuration created a GUI run")
+                    if runtime_cache.exists() and any(runtime_cache.iterdir()):
+                        raise RuntimeError("Invalid bulk configuration started managed-runtime preparation")
                     if page.get_by_text("Reads Table", exact=True).count():
                         raise RuntimeError("Desktop GUI unexpectedly exposes a FASTQ reads-table field")
+
+                    samples, comparisons, genome = _write_valid_bulk_fixture(workdir_path)
+                    page.get_by_label("Sample Table", exact=True).fill(str(samples))
+                    page.get_by_label("Comparison Table", exact=True).fill(str(comparisons))
+                    page.get_by_label("Genome", exact=True).fill(str(genome))
+                    page.get_by_role("button", name="Update page config", exact=True).click(force=True)
+                    page.get_by_text("Config is ready to run.", exact=True).wait_for(timeout=30_000)
+                    if start_button.is_disabled():
+                        raise RuntimeError("Start run remains disabled after the bulk configuration becomes valid")
                     context.close()
                 finally:
                     browser.close()

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc7"
+__version__ = "0.2.0rc8"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/gui_app.py
+++ b/src/fp_tools/gui_app.py
@@ -1464,6 +1464,7 @@ def _render_page_loader(tool: str) -> None:
 def _render_run_controls(run_dir: Path, label: str) -> None:
     normalized = normalize_config(st.session_state.current_config)
     validation_errors = validate_gui_config(normalized)
+    has_validation_errors = bool(validation_errors)
     tool = _current_config_tool() or "none"
     with st.container(border=True):
         st.markdown(
@@ -1487,7 +1488,12 @@ def _render_run_controls(run_dir: Path, label: str) -> None:
             st.success("Config is ready to run.")
         with st.expander("Preview runnable YAML", expanded=False):
             st.code(config_to_yaml_text(normalized), language="yaml")
-        if st.button("Start run", key=f"run_{label}", width="stretch"):
+        if st.button(
+            "Start run",
+            key=f"run_{label}",
+            width="stretch",
+            disabled=has_validation_errors,
+        ):
             if validation_errors:
                 st.error("Run not started. Fix the config errors above first.")
                 return

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc7",
-  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc7",
+  "runtime_version": "0.2.0rc8",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc8",
   "components": {
     "core": {
       "commands": [
@@ -37,23 +37,23 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc7-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc7-linux-x86_64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc8-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc8-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc7-linux-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-linux-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc7-linux-arm64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc8-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc8-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-macos-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc7-macos-arm64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc7-linux-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc8-linux-x86_64.tar.gz"}
     }
   }
 }

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from fp_tools import gui_app
 from fp_tools.command_registry import COMMAND_TARGETS, dispatch_command
 from fp_tools.desktop import INTERNAL_LIST_EXAMPLES_FLAG, main as desktop_main
 from fp_tools.gui_app import (
@@ -21,6 +22,53 @@ from fp_tools.utils.subprocess_commands import (
 
 
 class GuiLauncherTests(unittest.TestCase):
+    def test_run_control_state_tracks_validation_and_keeps_launch_guard(self):
+        normalized = {
+            "version": 1,
+            "run_mode": "single",
+            "defaults": {},
+            "samples": [
+                {
+                    "tool": "bulk-footprinting",
+                    "sample_table": "samples.tsv",
+                    "comparison_table": "comparisons.tsv",
+                    "genome": "genome.fa",
+                    "outdir": "results",
+                }
+            ],
+            "comparisons": [],
+        }
+        fake_streamlit = MagicMock()
+        fake_streamlit.session_state.current_config = normalized
+        fake_streamlit.button.return_value = True
+
+        with (
+            patch.object(gui_app, "st", fake_streamlit),
+            patch.object(gui_app, "normalize_config", return_value=normalized),
+            patch.object(gui_app, "validate_gui_config", return_value=["missing input"]),
+            patch.object(gui_app, "_current_config_tool", return_value="bulk-footprinting"),
+            patch.object(gui_app, "materialize_run_config") as materialize,
+            patch.object(gui_app, "launch_config_async") as launch,
+        ):
+            gui_app._render_run_controls(Path("runs"), label="bulk_footprinting")
+
+        self.assertTrue(fake_streamlit.button.call_args.kwargs["disabled"])
+        materialize.assert_not_called()
+        launch.assert_not_called()
+
+        fake_streamlit.reset_mock()
+        fake_streamlit.session_state.current_config = normalized
+        fake_streamlit.button.return_value = False
+        with (
+            patch.object(gui_app, "st", fake_streamlit),
+            patch.object(gui_app, "normalize_config", return_value=normalized),
+            patch.object(gui_app, "validate_gui_config", return_value=[]),
+            patch.object(gui_app, "_current_config_tool", return_value="bulk-footprinting"),
+        ):
+            gui_app._render_run_controls(Path("runs"), label="bulk_footprinting")
+
+        self.assertFalse(fake_streamlit.button.call_args.kwargs["disabled"])
+
     def test_local_startup_explains_browser_and_ssh_access(self):
         text = "\n".join(_startup_messages("127.0.0.1", 8891, Path("runs")))
         self.assertIn("http://127.0.0.1:8891", text)


### PR DESCRIPTION
Closes #33.

## Changes
- disable Start run through the native Streamlit control state whenever GUI validation reports errors
- retain the launch-time validation guard
- extend unit and frozen desktop regression coverage for invalid and valid configurations
- prepare v0.2.0rc8 release metadata and download links

## Local verification
- 401 tests passed; 1 skipped
- all 22 console commands passed smoke testing
- source GUI browser audit passed at three viewport sizes
- strict MkDocs build and 32-page responsive audit passed
- pip check and sdist/twine checks passed