### PR TITLE
Make bulk-footprinting start from BAM inputs only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,11 @@ unless the user explicitly asks to publish the manuscript source.
 - Every GUI and the Windows/macOS desktop applications start bulk workflows
   from coordinate-sorted BAM/BAI and matching peak BED files. Do not expose
   FASTQ-to-BAM preparation through GUI forms, GUI YAML, or desktop dispatch.
-- `prepare-atac` and `bulk-footprinting --reads-table` are supported only by
-  the Linux CLI and Linux container. Native macOS/Windows commands must reject
-  raw-read mode before downloads, filesystem writes, or runtime setup.
+- `bulk-footprinting` starts only from coordinate-sorted BAM/BAI and matching
+  peak BED files on every platform. FASTQ-to-BAM preparation is a separate
+  `prepare-atac` command supported only by the Linux CLI and Linux container.
+  Native macOS/Windows `prepare-atac` execution must reject before downloads,
+  filesystem writes, or runtime setup.
 - Use the current public command names in docs and examples:
   `prepare-atac`, `bulk-footprinting`, `atac-correct`, `call-footprints`,
   `match-motifs`, `diff-footprints`, `normalize-bigwig`, `plot-aggregate`,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc8
+version: 0.2.0rc9
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -27,8 +27,9 @@ a separately planned breaking release explicitly changes the contract.
   complete Linux container retained as an explicit backend.
 - Cross-platform one-command bulk analysis from coordinate-sorted BAM/BAI and
   matching peak BED files through portable multi-comparison HTML reports.
-- Optional Linux CLI/container bulk analysis from FASTQ files or public run
-  accessions through the same downstream workflow.
+- Separate Linux CLI/container FASTQ preparation through `prepare-atac`, which
+  writes the BAM/BAI and peak BED sample table accepted by the downstream bulk
+  workflow.
 - Tn5 bias correction, background scaling, footprint scoring, candidate calls,
   known-motif matching, de novo motif preparation, and aggregate plotting.
 - Replicate-aware differential footprint reports, including per-sample motif

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ The wrapper runs `atac-correct`, `call-footprints`, `match-motifs`,
 directly. `diff-footprints --comparison-axis regions` compares matched genomic
 region sets within one sample or across biological replicates.
 
-FASTQ-to-BAM preparation is available through `prepare-atac` on the Linux CLI
-and in the Linux container. The GUI and native macOS/Windows installations
-start from BAM/BAI and peak BED files.
+Optional FASTQ-to-BAM preparation is a separate `prepare-atac` command on the
+Linux CLI and in the Linux container. `bulk-footprinting`, the GUI, and native
+macOS/Windows installations start from BAM/BAI and peak BED files.
 
 ## Single-cell ATAC-seq
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -58,10 +58,11 @@ Primary current API checks:
 
 Platform contract checks:
 
-- Linux CLI and the Linux container support `prepare-atac` and
-  `bulk-footprinting --reads-table`.
-- Native macOS and Windows commands reject raw-read mode before downloads or
-  output creation while keeping `prepare-atac --help` available.
+- Linux CLI and the Linux container support FASTQ preprocessing through the
+  separate `prepare-atac` command.
+- `bulk-footprinting` accepts only BAM/BAI plus peak BED sample tables on every
+  platform. Native macOS and Windows keep `prepare-atac --help` available but
+  reject execution before downloads or output creation.
 - Every GUI and both desktop bundles accept BAM/BAI plus peak BED inputs and
   reject `prepare-atac`, `reads_table`, and equivalent extra arguments.
 - Non-Linux runtime manifests expose the optional MEME component only; Linux

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,7 @@ prepare-atac --samples metadata.tsv --genome hg38 --outdir project
 
 **Primary inputs**
 
-- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [ENCODE and local examples](get-started/workflows/bulk-atac-seq.md#optional-fastq-preparation-on-linux).
+- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [bulk workflow guide](get-started/workflows/bulk-atac-seq.md).
 - `--genome` — packaged `hg38` or `mm10` reference label, or a custom label used with explicit reference options.
 - `--outdir` — project directory represented by `{project}` below.
 
@@ -199,24 +199,17 @@ bulk-footprinting --sample-table samples.tsv --comparison-table comparisons.tsv 
 | `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for the workflow stages. |
 | `{project}/logs/bulk_footprinting/{stage}.stdout.log` and `{stage}.stderr.log` | Stage-specific logs for troubleshooting. |
 
-Linux CLI and Linux container users may instead use `--reads-table` for FASTQ
-or public-run preprocessing. This option and its associated preparation flags
-are unavailable in the GUI and native macOS/Windows installations.
+FASTQ preprocessing is intentionally separate. Linux users can run
+[`prepare-atac`](#prepare-atac) first, then provide its generated
+`metadata/samples.tsv` to this command.
 
 **Complete options**
 
 ```text
-usage: bulk-footprinting [-h]
-                         (--sample-table SAMPLE_TABLE | --reads-table READS_TABLE)
-                         --comparison-table COMPARISON_TABLE --genome GENOME
-                         [--blacklist BLACKLIST] [--config CONFIG]
-                         [--profile {modern,homer-atac}]
-                         [--reference-dir REFERENCE_DIR] [--fasta FASTA]
-                         [--bowtie2-index BOWTIE2_INDEX] [--tss TSS]
-                         [--macs-genome-size MACS_GENOME_SIZE]
-                         [--max-parallel-samples MAX_PARALLEL_SAMPLES]
-                         [--memory-gb MEMORY_GB] [--keep-intermediates]
-                         [--motifs [MOTIFS ...]] [--motif-db MOTIF_DB]
+usage: bulk-footprinting [-h] --sample-table SAMPLE_TABLE --comparison-table
+                         COMPARISON_TABLE --genome GENOME
+                         [--blacklist BLACKLIST] [--motifs [MOTIFS ...]]
+                         [--motif-db MOTIF_DB]
                          [--normalization {none,condition-quantile,sample-quantile}]
                          [--plot-aggregate {sig,all,top,off}]
                          [--review-format {auto,bundle,standalone,none}]
@@ -230,32 +223,11 @@ options:
   -h, --help            show this help message and exit
   --sample-table SAMPLE_TABLE
                         TSV with sample, condition, BAM, and peak BED columns.
-  --reads-table READS_TABLE
-                        Linux CLI/container only: TSV/CSV with local FASTQ
-                        paths or public run accessions; runs preparation
-                        before footprinting.
   --comparison-table COMPARISON_TABLE
                         TSV with comparison, cond1, and cond2 columns.
-  --genome GENOME       Reference FASTA for aligned input, or hg38/mm10/custom
-                        label for raw reads.
+  --genome GENOME       Reference FASTA matching the BAM and peak coordinates.
   --blacklist BLACKLIST
                         Optional blacklist BED used during bias correction.
-  --config CONFIG       Optional prepare-atac YAML for raw reads.
-  --profile {modern,homer-atac}
-                        Raw-read processing profile (default: modern).
-  --reference-dir REFERENCE_DIR
-                        Reference cache root for raw reads.
-  --fasta FASTA         Custom reference FASTA for raw reads.
-  --bowtie2-index BOWTIE2_INDEX
-                        Existing Bowtie2 index prefix for raw reads.
-  --tss TSS             Optional TSS BED for raw-read QC.
-  --macs-genome-size MACS_GENOME_SIZE
-                        MACS3 genome size for a custom genome.
-  --max-parallel-samples MAX_PARALLEL_SAMPLES
-                        Maximum raw-read samples processed concurrently.
-  --memory-gb MEMORY_GB
-                        Total memory budget for raw-read processing.
-  --keep-intermediates  Keep raw-read intermediate files.
   --motifs [MOTIFS ...]
                         Optional motif files.
   --motif-db MOTIF_DB   Built-in motif database (default:

--- a/docs/get-started/commands/bulk-footprinting.md
+++ b/docs/get-started/commands/bulk-footprinting.md
@@ -37,6 +37,6 @@ bulk-footprinting --sample-table samples.tsv --comparison-table comparisons.tsv 
 | `{project}/logs/bulk_footprinting/bulk_footprinting_commands.sh` | Exact commands generated for the workflow stages. |
 | `{project}/logs/bulk_footprinting/{stage}.stdout.log` and `{stage}.stderr.log` | Stage-specific logs for troubleshooting. |
 
-Linux CLI and Linux container users may instead use `--reads-table` for FASTQ
-or public-run preprocessing. This option and its associated preparation flags
-are unavailable in the GUI and native macOS/Windows installations.
+FASTQ preprocessing is intentionally separate. Linux users can run
+[`prepare-atac`](prepare-atac.md) first, then provide its generated
+`metadata/samples.tsv` to this command.

--- a/docs/get-started/commands/prepare-atac.md
+++ b/docs/get-started/commands/prepare-atac.md
@@ -13,7 +13,7 @@ prepare-atac --samples metadata.tsv --genome hg38 --outdir project
 
 ## Primary inputs
 
-- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [ENCODE and local examples](../workflows/bulk-atac-seq.md#optional-fastq-preparation-on-linux).
+- `--samples` — TSV or CSV sample sheet containing `sample`, `condition`, and either paired `fastq_1`/`fastq_2` paths or URLs. See the [bulk workflow guide](../workflows/bulk-atac-seq.md).
 - `--genome` — packaged `hg38` or `mm10` reference label, or a custom label used with explicit reference options.
 - `--outdir` — project directory represented by `{project}` below.
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -19,8 +19,8 @@ starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 Download the app for your computer, then open it. The GUI starts in your
 browser.
 
-[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc8/fp-tools-gui-windows-x64.exe){ .md-button }
-[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc8/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
+[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc9/fp-tools-gui-windows-x64.exe){ .md-button }
+[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc9/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
 The preview apps are unsigned. Windows may ask you to confirm the download. On
 macOS, Control-click the app and choose **Open** the first time.
@@ -63,6 +63,13 @@ server address. The port must be permitted by the server firewall.
 
     The Linux container also supports FASTQ-to-BAM preparation with
     `prepare-atac`; native Windows and macOS installations do not.
+
+??? note "Optional FASTQ-to-BAM preparation"
+
+    The footprinting workflows start from BAM/BAI and peak BED files. Linux
+    users who need read preprocessing can run
+    [`prepare-atac`](commands/prepare-atac.md) separately before starting the
+    bulk workflow.
 
 ## Start an analysis
 

--- a/docs/get-started/tool-overview.md
+++ b/docs/get-started/tool-overview.md
@@ -5,8 +5,8 @@ The guides below cover common inputs and outputs. See the
 
 If you are new to fp-tools, start with the [bulk ATAC-seq workflow](workflows/bulk-atac-seq.md):
 it includes a BAM/peak sample sheet, an explicit comparison table, ENCODE
-downloads, and the expected output layout. A separate section on the same page
-covers optional Linux-only FASTQ preparation.
+downloads, and the expected output layout. Optional Linux-only FASTQ
+preprocessing is kept separate under `prepare-atac`.
 
 ## Core analysis
 

--- a/docs/get-started/workflows/bulk-atac-seq.md
+++ b/docs/get-started/workflows/bulk-atac-seq.md
@@ -26,21 +26,18 @@ bulk-footprinting --sample-table encode_hepg2_k562_bams.tsv \
 Repeated condition names in a sample sheet define biological replicates. BAM,
 peak, blacklist, and genome files must use the same genome assembly.
 
-## Optional FASTQ preparation on Linux
+??? note "Optional FASTQ-to-BAM preparation"
 
-The Linux CLI and Linux container can also run the workflow from local FASTQ
-files or public run accessions. This route is not exposed in any GUI or native
-macOS/Windows installation.
+    On Linux, [`prepare-atac`](../commands/prepare-atac.md) can prepare FASTQ
+    files as BAM/BAI and peak BED inputs. Run it separately before
+    `bulk-footprinting`:
 
-Download the [ENCODE FASTQ sample sheet](../../demos/data/encode/encode_hepg2_k562_fastq_urls.tsv)
-and the [HepG2/K562 comparison file](../../demos/data/encode/encode_hepg2_k562_comparisons.tsv).
-For your own data, begin with the [local FASTQ template](../../demos/data/encode/local_fastq_template.tsv).
+    ```bash
+    prepare-atac --samples reads.tsv --genome hg38 --outdir prepared_project
+    ```
 
-```bash
-bulk-footprinting --reads-table encode_hepg2_k562_fastq_urls.tsv \
-  --comparison-table encode_hepg2_k562_comparisons.tsv --genome hg38 \
-  --outdir project --cores 8
-```
+    Use the generated `metadata/samples.tsv` with `bulk-footprinting`. This
+    preprocessing step is not part of the bulk footprinting wrapper.
 
 ## Review the results
 

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc8
+#      python -m pip install fp-tools-bio==0.2.0rc9
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc8}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc9}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc8</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc9</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc8"
+version = "0.2.0rc9"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -147,7 +147,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc8"
+version = "0.2.0rc9"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc8"
+__version__ = "0.2.0rc9"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/gui_config.py
+++ b/src/fp_tools/gui_config.py
@@ -361,10 +361,13 @@ def validate_config(config: Mapping[str, Any]) -> list[str]:
             if tool == "bulk-footprinting":
                 reads_table = str(item.get("reads_table") or "").strip()
                 sample_table = str(item.get("sample_table") or "").strip()
-                if bool(reads_table) == bool(sample_table):
+                if reads_table:
                     errors.append(
-                        f"{job_name}: provide exactly one of 'reads_table' or 'sample_table'"
+                        f"{job_name}: 'bulk-footprinting' starts from 'sample_table'; "
+                        "run 'prepare-atac' separately for FASTQ inputs"
                     )
+                if not sample_table:
+                    errors.append(f"{job_name}: missing required field 'sample_table'")
             if tool == "diff-footprints":
                 comparison_axis = str(item.get("comparison_axis") or item.get("comparison-axis") or "conditions")
                 signals = item.get("signals") or []

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc8",
-  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc8",
+  "runtime_version": "0.2.0rc9",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc9",
   "components": {
     "core": {
       "commands": [
@@ -37,23 +37,23 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc8-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc8-linux-x86_64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc9-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc9-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc8-linux-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-linux-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc8-linux-arm64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc9-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc9-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-macos-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc8-macos-arm64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc8-linux-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc9-linux-x86_64.tar.gz"}
     }
   }
 }

--- a/src/fp_tools/tools/bulk_footprinting.py
+++ b/src/fp_tools/tools/bulk_footprinting.py
@@ -4,15 +4,13 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import shlex
 import subprocess
 import sys
 from pathlib import Path
 
-from fp_tools.platform_support import require_raw_read_preparation_support
-from fp_tools.runtime import RuntimeProvisionError, add_runtime_argument, prepare_command_runtime
+from fp_tools.runtime import RuntimeProvisionError, add_runtime_argument
 from fp_tools.utils.project_layout import (
     analysis_peaks_path,
     comparison_dir,
@@ -160,116 +158,12 @@ def build_commands(args: argparse.Namespace) -> list[tuple[str, list[str]]]:
     return commands
 
 
-def build_prepare_command(args: argparse.Namespace) -> list[str]:
-    """Build the raw-read preparation stage used by the end-to-end wrapper."""
-
-    command = [
-        "prepare-atac",
-        "--samples",
-        str(args.reads_table),
-        "--genome",
-        str(args.genome),
-        "--outdir",
-        str(Path(args.outdir).expanduser().resolve()),
-        "--cores",
-        str(args.cores),
-        "--runtime",
-        "system",
-    ]
-    scalar_options = {
-        "config": "--config",
-        "profile": "--profile",
-        "reference_dir": "--reference-dir",
-        "fasta": "--fasta",
-        "bowtie2_index": "--bowtie2-index",
-        "blacklist": "--blacklist",
-        "tss": "--tss",
-        "macs_genome_size": "--macs-genome-size",
-        "max_parallel_samples": "--max-parallel-samples",
-        "memory_gb": "--memory-gb",
-    }
-    for attribute, flag in scalar_options.items():
-        value = getattr(args, attribute, None)
-        if value is not None:
-            command.extend([flag, str(value)])
-    if args.keep_intermediates:
-        command.append("--keep-intermediates")
-    if args.force:
-        command.append("--no-resume")
-    if args.fail_fast:
-        command.append("--fail-fast")
-    return command
-
-
-def _prepared_inputs(project: Path) -> tuple[Path, str, str | None]:
-    sample_table = project / "metadata" / "samples.tsv"
-    reference_path = project / "metadata" / "reference.json"
-    if not sample_table.is_file() or not reference_path.is_file():
-        raise ValueError(
-            "Raw-read preparation did not produce metadata/samples.tsv and metadata/reference.json"
-        )
-    reference = json.loads(reference_path.read_text(encoding="utf-8"))
-    genome = str(reference.get("fasta") or "")
-    if not genome:
-        raise ValueError("The prepared reference metadata does not contain a genome FASTA")
-    blacklist = str(reference.get("blacklist") or "") or None
-    return sample_table, genome, blacklist
-
-
-def _planned_prepared_inputs(args: argparse.Namespace, project: Path) -> argparse.Namespace:
-    """Resolve predictable downstream paths without creating or downloading data."""
-
-    planned = argparse.Namespace(**vars(args))
-    planned.sample_table = str(project / "metadata" / "samples.tsv")
-    reference_root = Path(
-        args.reference_dir or Path.home() / ".cache" / "fp-tools" / "references"
-    ).expanduser()
-    planned.genome = str(
-        Path(args.fasta).expanduser().resolve()
-        if args.fasta
-        else reference_root / str(args.genome) / f"{args.genome}.fa"
-    )
-    if args.blacklist:
-        planned.blacklist = str(Path(args.blacklist).expanduser().resolve())
-    elif args.genome in {"hg38", "mm10"}:
-        planned.blacklist = str(
-            reference_root / str(args.genome) / f"{args.genome}.blacklist.bed"
-        )
-    else:
-        planned.blacklist = None
-    return planned
-
-
 def run_bulk_footprinting(args: argparse.Namespace) -> int:
     project = Path(args.outdir).expanduser().resolve()
     project.mkdir(parents=True, exist_ok=True)
     log_dir = project / "logs" / "bulk_footprinting"
     log_dir.mkdir(parents=True, exist_ok=True)
     comparisons = read_comparison_table(args.comparison_table)
-    prepare_command = None
-    if args.reads_table:
-        prepare_command = build_prepare_command(args)
-        if args.dry_run:
-            print(f"[prepare-atac] {_quote([*prepare_command, '--dry-run'])}")
-            for label, command in build_commands(_planned_prepared_inputs(args, project)):
-                print(f"[{label}] {_quote(command)}")
-            return 0
-        if not (args.resume and not args.force and (project / "metadata" / "samples.tsv").is_file()):
-            code = _run(
-                prepare_command,
-                log_dir / "prepare-atac.stdout.log",
-                log_dir / "prepare-atac.stderr.log",
-            )
-            if code:
-                print(f"prepare-atac failed with exit code {code}; see {log_dir}", file=sys.stderr)
-                return code
-        else:
-            print("[resume] prepare-atac: complete")
-        sample_table, genome, blacklist = _prepared_inputs(project)
-        args.sample_table = str(sample_table)
-        args.genome = genome
-        args.blacklist = blacklist
-
     samples = read_sample_table(args.sample_table)
     conditions = {row.condition for row in samples}
     unknown = sorted({value for row in comparisons for value in (row.cond1, row.cond2)} - conditions)
@@ -280,8 +174,7 @@ def run_bulk_footprinting(args: argparse.Namespace) -> int:
     commands = build_commands(args)
     command_file = log_dir / "bulk_footprinting_commands.sh"
     lines = ["#!/usr/bin/env bash", "set -euo pipefail", "", "# Generated by bulk-footprinting.", ""]
-    logged_commands = ([('prepare-atac', prepare_command)] if prepare_command else []) + commands
-    for label, command in logged_commands:
+    for label, command in commands:
         lines.extend([f"# {label}", _quote(command), ""])
     command_file.write_text("\n".join(lines), encoding="utf-8")
     command_file.chmod(0o755)
@@ -313,28 +206,10 @@ def run_bulk_footprinting(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bulk-footprinting", description=__doc__)
-    source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--sample-table", help="TSV with sample, condition, BAM, and peak BED columns.")
-    source.add_argument(
-        "--reads-table",
-        help=(
-            "Linux CLI/container only: TSV/CSV with local FASTQ paths or public run "
-            "accessions; runs preparation before footprinting."
-        ),
-    )
+    parser.add_argument("--sample-table", required=True, help="TSV with sample, condition, BAM, and peak BED columns.")
     parser.add_argument("--comparison-table", required=True, help="TSV with comparison, cond1, and cond2 columns.")
-    parser.add_argument("--genome", required=True, help="Reference FASTA for aligned input, or hg38/mm10/custom label for raw reads.")
+    parser.add_argument("--genome", required=True, help="Reference FASTA matching the BAM and peak coordinates.")
     parser.add_argument("--blacklist", help="Optional blacklist BED used during bias correction.")
-    parser.add_argument("--config", help="Optional prepare-atac YAML for raw reads.")
-    parser.add_argument("--profile", choices=["modern", "homer-atac"], default="modern", help="Raw-read processing profile (default: modern).")
-    parser.add_argument("--reference-dir", help="Reference cache root for raw reads.")
-    parser.add_argument("--fasta", help="Custom reference FASTA for raw reads.")
-    parser.add_argument("--bowtie2-index", help="Existing Bowtie2 index prefix for raw reads.")
-    parser.add_argument("--tss", help="Optional TSS BED for raw-read QC.")
-    parser.add_argument("--macs-genome-size", help="MACS3 genome size for a custom genome.")
-    parser.add_argument("--max-parallel-samples", type=int, help="Maximum raw-read samples processed concurrently.")
-    parser.add_argument("--memory-gb", type=float, help="Total memory budget for raw-read processing.")
-    parser.add_argument("--keep-intermediates", action="store_true", help="Keep raw-read intermediate files.")
     parser.add_argument("--motifs", nargs="*", help="Optional motif files.")
     parser.add_argument("--motif-db", default="jaspar2026_vertebrates", help="Built-in motif database (default: jaspar2026_vertebrates).")
     parser.add_argument("--normalization", choices=["none", "condition-quantile", "sample-quantile"], default="none", help="Differential-stage normalization (default: none).")
@@ -361,21 +236,12 @@ def _require_input_file(value: str | None, flag: str) -> None:
 def _preflight_input_paths(args: argparse.Namespace) -> None:
     """Reject missing workflow inputs before runtime provisioning or writes."""
 
-    _require_input_file(args.reads_table or args.sample_table, "--reads-table" if args.reads_table else "--sample-table")
+    _require_input_file(args.sample_table, "--sample-table")
     _require_input_file(args.comparison_table, "--comparison-table")
-    if args.reads_table:
-        for value, flag in (
-            (args.config, "--config"),
-            (args.fasta, "--fasta"),
-            (args.blacklist, "--blacklist"),
-            (args.tss, "--tss"),
-        ):
-            _require_input_file(value, flag)
-    else:
-        _require_input_file(args.genome, "--genome")
-        _require_input_file(args.blacklist, "--blacklist")
-        for motif in args.motifs or []:
-            _require_input_file(motif, "--motifs")
+    _require_input_file(args.genome, "--genome")
+    _require_input_file(args.blacklist, "--blacklist")
+    for motif in args.motifs or []:
+        _require_input_file(motif, "--motifs")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -384,55 +250,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(raw_args)
     if args.resume and args.force:
         parser.error("--resume and --force are mutually exclusive")
-    if args.reads_table:
-        try:
-            require_raw_read_preparation_support()
-        except ValueError as exc:
-            parser.error(str(exc))
-    elif any(
-        argument.split("=", 1)[0]
-        in {
-            "--config",
-            "--profile",
-            "--reference-dir",
-            "--fasta",
-            "--bowtie2-index",
-            "--tss",
-            "--macs-genome-size",
-            "--max-parallel-samples",
-            "--memory-gb",
-            "--keep-intermediates",
-        }
-        for argument in raw_args
-    ):
-        parser.error("raw-read preparation options require --reads-table")
     try:
         _preflight_input_paths(args)
-        if args.reads_table and not args.dry_run:
-            delegated = prepare_command_runtime(
-                "bulk-footprinting",
-                raw_args,
-                args.runtime,
-                "core",
-                {
-                    "--sample-table",
-                    "--reads-table",
-                    "--comparison-table",
-                    "--genome",
-                    "--blacklist",
-                    "--config",
-                    "--reference-dir",
-                    "--fasta",
-                    "--bowtie2-index",
-                    "--tss",
-                    "--outdir",
-                    "--motifs",
-                },
-            )
-            if delegated is not None:
-                return delegated
-            if args.profile == "homer-atac":
-                prepare_command_runtime("bulk-footprinting", raw_args, args.runtime, "homer", set())
         return run_bulk_footprinting(args)
     except (ValueError, RuntimeProvisionError) as exc:
         parser.error(str(exc))

--- a/tests/test_cli_and_config_smoke.py
+++ b/tests/test_cli_and_config_smoke.py
@@ -28,7 +28,7 @@ CONFIG_DIR = ROOT / "examples" / "gui_configs"
 
 
 class CliAndConfigSmokeTest(unittest.TestCase):
-    def test_bulk_config_accepts_exactly_one_input_level(self):
+    def test_bulk_config_requires_aligned_sample_table(self):
         base = {
             "tool": "bulk-footprinting",
             "comparison_table": "comparisons.tsv",
@@ -41,9 +41,9 @@ class CliAndConfigSmokeTest(unittest.TestCase):
             "samples": [{**base, "reads_table": "reads.tsv", "sample_table": "samples.tsv"}],
             "comparisons": [],
         }
-        self.assertEqual(validate_config(raw), [])
         self.assertEqual(validate_config(aligned), [])
-        self.assertTrue(any("exactly one" in value for value in validate_config(both)))
+        self.assertTrue(any("run 'prepare-atac' separately" in value for value in validate_config(raw)))
+        self.assertTrue(any("run 'prepare-atac' separately" in value for value in validate_config(both)))
 
     def test_gui_accepts_bam_bulk_config_and_rejects_raw_reads(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -282,12 +282,11 @@ class DocsEntryPointContractTest(unittest.TestCase):
         guide = (
             ROOT / "docs" / "get-started" / "workflows" / "bulk-atac-seq.md"
         ).read_text(encoding="utf-8")
-        self.assertIn("encode_hepg2_k562_fastq_urls.tsv", guide)
         self.assertIn("encode_hepg2_k562_bams.tsv", guide)
         self.assertIn("encode_hepg2_k562_comparisons.tsv", guide)
-        self.assertIn("local_fastq_template.tsv", guide)
         self.assertIn("local_bam_peak_template.tsv", guide)
-        self.assertIn("bulk-footprinting --reads-table", guide)
+        self.assertIn('??? note "Optional FASTQ-to-BAM preparation"', guide)
+        self.assertIn("prepare-atac --samples", guide)
         self.assertIn("bulk-footprinting --sample-table", guide)
         self.assertEqual(guide.count("```bash"), 2)
         for unnecessary_detail in (

--- a/tests/test_platform_scope.py
+++ b/tests/test_platform_scope.py
@@ -31,107 +31,26 @@ class PlatformScopeTest(unittest.TestCase):
             prepare_atac.main(["--help"])
         self.assertEqual(raised.exception.code, 0)
 
-    def test_bulk_raw_mode_rejects_non_linux_for_every_runtime(self):
-        for host in ("Darwin", "Windows"):
-            for runtime_mode in ("auto", "managed", "system", "container"):
-                with self.subTest(host=host, runtime=runtime_mode), tempfile.TemporaryDirectory() as tmpdir:
-                    output = Path(tmpdir) / "project"
-                    with mock.patch(
-                        "fp_tools.platform_support.platform.system", return_value=host
-                    ), mock.patch.object(
-                        bulk_footprinting, "prepare_command_runtime"
-                    ) as runtime:
-                        with self.assertRaises(SystemExit) as raised:
-                            bulk_footprinting.main(
-                                [
-                                    "--reads-table",
-                                    "reads.tsv",
-                                    "--comparison-table",
-                                    "comparisons.tsv",
-                                    "--genome",
-                                    "hg38",
-                                    "--outdir",
-                                    str(output),
-                                    "--runtime",
-                                    runtime_mode,
-                                ]
-                            )
-                    self.assertEqual(raised.exception.code, 2)
-                    self.assertFalse(output.exists())
-                    runtime.assert_not_called()
-
-    def test_linux_bulk_raw_mode_reaches_the_existing_workflow(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            reads = root / "reads.tsv"
-            comparisons = root / "comparisons.tsv"
-            reads.write_text("sample\tcondition\tfastq_1\n", encoding="utf-8")
-            comparisons.write_text("comparison\tcond1\tcond2\n", encoding="utf-8")
-            with mock.patch(
-                "fp_tools.platform_support.platform.system", return_value="Linux"
-            ), mock.patch.object(
-                bulk_footprinting, "run_bulk_footprinting", return_value=0
-            ) as run:
-                result = bulk_footprinting.main(
-                    [
-                        "--reads-table",
-                        str(reads),
-                        "--comparison-table",
-                        str(comparisons),
-                        "--genome",
-                        "hg38",
-                        "--outdir",
-                        str(root / "project"),
-                        "--dry-run",
-                    ]
-                )
-        self.assertEqual(result, 0)
-        run.assert_called_once()
-
-    def test_bam_mode_rejects_raw_only_options(self):
+    def test_bulk_wrapper_rejects_raw_input_and_preparation_options(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             output = Path(tmpdir) / "project"
-            with self.assertRaises(SystemExit) as raised:
-                bulk_footprinting.main(
-                    [
-                        "--sample-table",
-                        "samples.tsv",
-                        "--comparison-table",
-                        "comparisons.tsv",
-                        "--genome",
-                        "genome.fa.gz",
-                        "--outdir",
-                        str(output),
-                        "--profile",
-                        "modern",
-                    ]
-                )
-            self.assertEqual(raised.exception.code, 2)
-            self.assertFalse(output.exists())
-
-    def test_missing_raw_input_is_rejected_before_runtime_setup(self):
-        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.object(
-            bulk_footprinting, "prepare_command_runtime"
-        ) as runtime:
-            root = Path(tmpdir)
-            comparisons = root / "comparisons.tsv"
-            comparisons.write_text("comparison\tcond1\tcond2\n", encoding="utf-8")
-            with self.assertRaises(SystemExit) as raised:
-                bulk_footprinting.main(
-                    [
-                        "--reads-table",
-                        str(root / "missing.tsv"),
-                        "--comparison-table",
-                        str(comparisons),
-                        "--genome",
-                        "hg38",
-                        "--outdir",
-                        str(root / "project"),
-                    ]
-                )
-            self.assertEqual(raised.exception.code, 2)
-            runtime.assert_not_called()
-            self.assertFalse((root / "project").exists())
+            for extra in (("--reads-table", "reads.tsv"), ("--profile", "modern")):
+                with self.subTest(flag=extra[0]), self.assertRaises(SystemExit) as raised:
+                    bulk_footprinting.main(
+                        [
+                            "--sample-table",
+                            "samples.tsv",
+                            "--comparison-table",
+                            "comparisons.tsv",
+                            "--genome",
+                            "genome.fa.gz",
+                            "--outdir",
+                            str(output),
+                            *extra,
+                        ]
+                    )
+                self.assertEqual(raised.exception.code, 2)
+                self.assertFalse(output.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_wrappers.py
+++ b/tests/test_workflow_wrappers.py
@@ -8,58 +8,23 @@ from fp_tools.tools.bulk_footprinting import (
     _stage_complete,
     build_commands,
     build_parser,
-    build_prepare_command,
     run_bulk_footprinting,
 )
 from fp_tools.tools.find_signature_fp import read_marker_sites_from_diff
 
 
 class WorkflowWrapperTest(unittest.TestCase):
-    def test_bulk_wrapper_accepts_raw_reads_as_alternative_input(self):
-        args = build_parser().parse_args(
-            [
-                "--reads-table", "reads.tsv",
-                "--comparison-table", "comparisons.tsv",
-                "--genome", "hg38",
-                "--outdir", "project",
-                "--cores", "8",
-            ]
-        )
-        command = build_prepare_command(args)
-        self.assertEqual(command[0], "prepare-atac")
-        self.assertEqual(command[command.index("--samples") + 1], "reads.tsv")
-        self.assertEqual(command[command.index("--runtime") + 1], "system")
-        self.assertIn("--profile", command)
-
-    def test_raw_read_dry_run_prints_the_complete_chain(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            comparisons = root / "comparisons.tsv"
-            comparisons.write_text(
-                "comparison\tcond1\tcond2\nA_vs_B\tA\tB\n", encoding="utf-8"
-            )
-            args = build_parser().parse_args(
+    def test_bulk_wrapper_rejects_raw_read_input(self):
+        with self.assertRaises(SystemExit) as raised:
+            build_parser().parse_args(
                 [
-                    "--reads-table", str(root / "reads.tsv"),
-                    "--comparison-table", str(comparisons),
-                    "--genome", "hg38",
-                    "--outdir", str(root / "project"),
-                    "--dry-run",
+                    "--reads-table", "reads.tsv",
+                    "--comparison-table", "comparisons.tsv",
+                    "--genome", "hg38.fa",
+                    "--outdir", "project",
                 ]
             )
-            output = io.StringIO()
-            with contextlib.redirect_stdout(output):
-                self.assertEqual(run_bulk_footprinting(args), 0)
-            text = output.getvalue()
-            for stage in (
-                "prepare-atac",
-                "atac-correct",
-                "call-footprints",
-                "match-motifs",
-                "diff-footprints",
-                "review-multi-comparisons",
-            ):
-                self.assertIn(f"[{stage}]", text)
+        self.assertEqual(raised.exception.code, 2)
 
     def test_bulk_wrapper_plans_complete_command_chain(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- remove FASTQ/read-table preprocessing from `bulk-footprinting`
- keep FASTQ-to-BAM work exclusively in the Linux-only `prepare-atac` command
- collapse the optional preprocessing guidance and regenerate the API reference
- update regression tests and prepare version 0.2.0rc9

## Validation
- 397 passed, 1 skipped
- strict MkDocs build and browser audit passed
- all console-script smoke tests passed
- `pip check` and sdist `twine check` passed