### PR TITLE
Fix sidebar navigation group spacing

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc9
+version: 0.2.0rc10
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -19,8 +19,8 @@ starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 Download the app for your computer, then open it. The GUI starts in your
 browser.
 
-[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc9/fp-tools-gui-windows-x64.exe){ .md-button }
-[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc9/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
+[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc10/fp-tools-gui-windows-x64.exe){ .md-button }
+[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc10/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
 The preview apps are unsigned. Windows may ask you to confirm the download. On
 macOS, Control-click the app and choose **Open** the first time.

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc9
+#      python -m pip install fp-tools-bio==0.2.0rc10
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc9}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc10}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc9</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc10</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc9"
+version = "0.2.0rc10"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -147,7 +147,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc9"
+version = "0.2.0rc10"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/scripts/audit_desktop_gui.py
+++ b/scripts/audit_desktop_gui.py
@@ -17,6 +17,18 @@ from pathlib import Path
 from playwright.sync_api import sync_playwright
 
 
+SIDEBAR_FIRST_PAGES = (
+    ("Overview", "Home"),
+    ("Core workflow", "atac-correct"),
+    ("Workflow and interface", "bulk-footprinting"),
+    ("Signals and reports", "normalize-bigwig"),
+    ("De Novo Motif Discovery", "discover-motifs"),
+    ("Single-cell ATAC-seq", "pseudobulk-fragments"),
+    ("Configuration", "Config"),
+)
+MINIMUM_SIDEBAR_GAP_PX = 2.0
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as handle:
         handle.bind(("127.0.0.1", 0))
@@ -136,6 +148,125 @@ def _audit_page(
     context.close()
 
 
+def _audit_sidebar_navigation(
+    browser,
+    base_url: str,
+    width: int,
+    height: int,
+    device_scale_factor: float,
+    output: Path,
+    capture_screenshots: bool,
+) -> None:
+    """Assert that every group label clears its first button, including active rows."""
+
+    context = browser.new_context(
+        viewport={"width": width, "height": height},
+        device_scale_factor=device_scale_factor,
+    )
+    page = context.new_page()
+    try:
+        page.goto(f"{base_url}/?page=Home", wait_until="domcontentloaded")
+        page.locator(".fp-nav-group").first.wait_for(timeout=60_000)
+        page.wait_for_function(
+            "() => document.querySelectorAll('.fp-nav-group').length === 7",
+            timeout=60_000,
+        )
+        for active_group, page_name in SIDEBAR_FIRST_PAGES:
+            print(
+                f"Checking active sidebar row {page_name} at {width}px/DPR "
+                f"{device_scale_factor}",
+                flush=True,
+            )
+            page.locator(".fp-nav-group").evaluate_all(
+                """(headings, activeGroup) => headings.forEach(heading => {
+                  const container = heading.closest('[data-testid="stElementContainer"]');
+                  let sibling = container ? container.nextElementSibling : null;
+                  let button = null;
+                  while (sibling && !button) {
+                    button = sibling.querySelector('button');
+                    sibling = sibling.nextElementSibling;
+                  }
+                  if (button) button.disabled = heading.textContent.trim() === activeGroup;
+                })""",
+                active_group,
+            )
+            page.wait_for_timeout(50)
+            measurements = page.locator(".fp-nav-group").evaluate_all(
+                """headings => headings.map(heading => {
+                  const container = heading.closest('[data-testid="stElementContainer"]');
+                  let sibling = container ? container.nextElementSibling : null;
+                  let button = null;
+                  while (sibling && !button) {
+                    button = sibling.querySelector('button');
+                    sibling = sibling.nextElementSibling;
+                  }
+                  const headingBox = heading.getBoundingClientRect();
+                  const buttonBox = button ? button.getBoundingClientRect() : null;
+                  return {
+                    group: heading.textContent.trim(),
+                    headingBottom: headingBox.bottom,
+                    buttonTop: buttonBox ? buttonBox.top : null,
+                    gap: buttonBox ? buttonBox.top - headingBox.bottom : null,
+                    buttonText: button ? button.textContent.trim() : null,
+                    buttonDisabled: button ? button.disabled : null,
+                    clipped: heading.scrollWidth > heading.clientWidth + 1 ||
+                      heading.scrollHeight > heading.clientHeight + 1
+                  };
+                })"""
+            )
+            failures = []
+            for measurement in measurements:
+                if measurement["buttonTop"] is None:
+                    failures.append(f"{measurement['group']}: first navigation row was not found")
+                elif measurement["gap"] < MINIMUM_SIDEBAR_GAP_PX:
+                    failures.append(
+                        f"{measurement['group']}: heading-to-row gap is "
+                        f"{measurement['gap']:.2f}px; expected at least "
+                        f"{MINIMUM_SIDEBAR_GAP_PX:.2f}px"
+                    )
+                if measurement["clipped"]:
+                    failures.append(f"{measurement['group']}: heading text is clipped")
+            active = next(
+                (value for value in measurements if value["group"] == active_group),
+                None,
+            )
+            if active is None:
+                failures.append(f"{active_group}: active group heading was not found")
+            elif not active["buttonDisabled"]:
+                failures.append(
+                    f"{active_group}: first row {active['buttonText']!r} is not active"
+                )
+            elif active["buttonText"] != page_name:
+                failures.append(
+                    f"{active_group}: expected first row {page_name!r}, found "
+                    f"{active['buttonText']!r}"
+                )
+            if failures:
+                screenshot = output / f"sidebar-{page_name}-{width}-failure.png"
+                screenshot_note = "screenshot skipped"
+                if capture_screenshots:
+                    screenshot_note = f"screenshot: {screenshot}"
+                    try:
+                        page.screenshot(
+                            path=str(screenshot),
+                            full_page=False,
+                            animations="disabled",
+                            timeout=10_000,
+                        )
+                    except Exception as exc:
+                        screenshot_note = f"screenshot capture failed: {exc}"
+                raise RuntimeError(
+                    f"Sidebar audit failed for {page_name} at {width}px/DPR "
+                    f"{device_scale_factor}: {'; '.join(failures)}; {screenshot_note}"
+                )
+        print(
+            f"Audited every sidebar group at {width}x{height}, DPR {device_scale_factor}",
+            flush=True,
+        )
+    finally:
+        context.close()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("executable")
@@ -189,6 +320,20 @@ def main() -> int:
                                 output,
                                 not args.skip_screenshots,
                             )
+
+                    for width, height, scale in (
+                        (1920, 1080, 2.0),
+                        (1280, 720, 1.25),
+                    ):
+                        _audit_sidebar_navigation(
+                            browser,
+                            base_url,
+                            width,
+                            height,
+                            scale,
+                            output,
+                            not args.skip_screenshots,
+                        )
 
                     context = browser.new_context(viewport={"width": 1280, "height": 720})
                     page = context.new_page()

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc9"
+__version__ = "0.2.0rc10"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/gui_app.py
+++ b/src/fp_tools/gui_app.py
@@ -491,15 +491,20 @@ def _apply_page_style() -> None:
             line-height: 1.28;
         }
         .fp-nav-group {
-            margin: 0.72rem 0 0.28rem;
+            margin: 0;
             display: block;
-            padding-bottom: 0.18rem;
+            box-sizing: border-box;
+            padding: 0.72rem 0 0.46rem;
             color: #93a4b8;
             font-size: 0.72rem;
             font-weight: 800;
             letter-spacing: 0.06em;
             text-transform: uppercase;
             line-height: 1.1;
+        }
+        [data-testid="stMarkdown"]:has(.fp-nav-group)
+        [data-testid="stMarkdownContainer"] {
+            margin-bottom: 0 !important;
         }
         .fp-run-dir-pill {
             display: block;

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc9",
-  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc9",
+  "runtime_version": "0.2.0rc10",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc10",
   "components": {
     "core": {
       "commands": [
@@ -37,23 +37,23 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc9-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc9-linux-x86_64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc10-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc10-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc9-linux-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-linux-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc9-linux-arm64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc10-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc10-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-macos-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc9-macos-arm64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc9-linux-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc10-linux-x86_64.tar.gz"}
     }
   }
 }


### PR DESCRIPTION
## Summary

- prevent Streamlit's Markdown wrapper from collapsing sidebar group spacing
- preserve a visible gap between every group heading and its first navigation row
- add browser geometry regression coverage for all seven groups, including the active blue state
- prepare the fix as `0.2.0rc10`

Closes #41.

## Verification

- `397 passed, 1 skipped`
- all 22 console commands passed smoke testing
- `pip check` passed
- strict MkDocs build and browser documentation audit passed
- desktop GUI browser audit passed at 1920×1080/DPR 2, 1280×720/DPR 1.25, and 390px mobile width
- every sidebar group retained a 4.80 CSS px heading-to-row gap at both desktop targets
- source distribution passed `twine check`
