### PR TITLE
Fix GUI validation overflow and report controls

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           mkdocs build --clean --strict
           python scripts/audit_docs.py --site-dir site
+          python scripts/audit_report_plot_controls.py \
+            --fixture-dir /tmp/fp-tools-report-control-fixtures \
+            site/ENCODE-Cancer-Cell-lines-Footprinting/index.html
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc10
+version: 0.2.0rc11
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -61,6 +61,10 @@ a separately planned breaking release explicitly changes the contract.
   complete container remains available on amd64 and arm64.
 - Branded GitHub and MkDocs presentation with responsive embedded report and
   GUI demos plus automated desktop/mobile browser audits.
+- Responsive GUI validation output with contained long paths and locally
+  scrolling YAML previews, verified in the native Windows and macOS audits.
+- Browser-verified plot controls and SVG exports for aggregate and
+  aggregate-free reports, including explicit subplot-bound checks.
 - A manifest-pinned, storage-conscious ENCODE workflow for 17 biological
   replicates from seven cancer cell lines. Its resumable runner uses a
   pair-specific union of released IDR-thresholded peaks, peak-q95 scaling, and

--- a/docs/ENCODE-Cancer-Cell-lines-Footprinting/app.js
+++ b/docs/ENCODE-Cancer-Cell-lines-Footprinting/app.js
@@ -1375,7 +1375,7 @@ function combinedPanelSvg() {
   volcano.querySelector("style")?.remove();
   if (!state.hasAggregates) {
     const totalWidth = rankDisplayWidth + volcanoSize + gap;
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g transform="scale(${rankScale})">${rank.innerHTML}</g><g transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g></svg>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g data-export-cell="rank" data-source-width="${rankWidth}" data-source-height="${rankHeight}" data-cell-width="${rankDisplayWidth}" data-cell-height="${panelHeight}" data-scale="${rankScale}" transform="scale(${rankScale})">${rank.innerHTML}</g><g data-export-cell="volcano" data-source-width="${volcanoSize}" data-source-height="${volcanoSize}" data-cell-width="${volcanoSize}" data-cell-height="${panelHeight}" data-scale="1" transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g></svg>`;
   }
   const aggregate = aggregateGridSvg(),
     aggregateDocument = new DOMParser().parseFromString(
@@ -1387,7 +1387,8 @@ function combinedPanelSvg() {
     aggregateWidth = (aggregateBox.width || 600) * aggregateScale,
     totalWidth = rankDisplayWidth + volcanoSize + aggregateWidth + gap * 2;
   aggregateDocument.querySelector("style")?.remove();
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g transform="scale(${rankScale})">${rank.innerHTML}</g><g transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g><g transform="translate(${rankDisplayWidth + volcanoSize + gap * 2},0) scale(${aggregateScale})">${aggregateDocument.innerHTML}</g></svg>`;
+  aggregateDocument.querySelector(":scope > rect")?.remove();
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g data-export-cell="rank" data-source-width="${rankWidth}" data-source-height="${rankHeight}" data-cell-width="${rankDisplayWidth}" data-cell-height="${panelHeight}" data-scale="${rankScale}" transform="scale(${rankScale})">${rank.innerHTML}</g><g data-export-cell="volcano" data-source-width="${volcanoSize}" data-source-height="${volcanoSize}" data-cell-width="${volcanoSize}" data-cell-height="${panelHeight}" data-scale="1" transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g><g data-export-cell="aggregate" data-source-width="${aggregateBox.width || 600}" data-source-height="${aggregateBox.height || 600}" data-cell-width="${aggregateWidth}" data-cell-height="${panelHeight}" data-scale="${aggregateScale}" transform="translate(${rankDisplayWidth + volcanoSize + gap * 2},0) scale(${aggregateScale})">${aggregateDocument.innerHTML}</g></svg>`;
 }
 
 function svgDimensions(svg) {

--- a/docs/ENCODE-Cancer-Cell-lines-Footprinting/index.html
+++ b/docs/ENCODE-Cancer-Cell-lines-Footprinting/index.html
@@ -62,31 +62,7 @@
           <summary>Show/Hide</summary>
           <div class="options-grid">
             <section class="option-col options-actions">
-              <p class="section-title">Export</p>
-              <div class="card export-stack">
-                <label class="format-row"
-                  >Format
-                  <select id="figure-format" aria-label="Figure export format">
-                    <option value="svg">Editable SVG</option>
-                    <option value="png">PNG</option>
-                    <option value="pdf">Print / PDF</option>
-                  </select>
-                </label>
-                <button id="download-logo" type="button">Motif logos</button>
-                <button id="download-rank" type="button">Bar plot</button>
-                <button id="download-volcano" type="button">Volcano plot</button>
-                <button id="download-aggregate" class="aggregate-only" type="button">Aggregate plots</button>
-                <button id="download-panel" type="button">Combined panel</button>
-                <button id="download-tsv" type="button">Comparison TSV</button>
-                <a
-                  id="download-all"
-                  class="button-link"
-                  href="data/all_pairwise_results.tsv.gz"
-                  download
-                  >All results</a
-                >
-              </div>
-              <p class="section-title group-title">Groups</p>
+              <p class="section-title">Groups</p>
               <div class="card control-stack">
                 <div id="color-controls" class="color-controls"></div>
                 <label class="rank-sort-control" title="Switch the waterfall ranking metric">
@@ -130,6 +106,30 @@
                     title="Comma-separated TF names, motif IDs, or output prefixes"
                   />
                 </label>
+              </div>
+              <p class="section-title group-title">Export</p>
+              <div class="card export-stack">
+                <label class="format-row"
+                  >Format
+                  <select id="figure-format" aria-label="Figure export format">
+                    <option value="svg">Editable SVG</option>
+                    <option value="png">PNG</option>
+                    <option value="pdf">Print / PDF</option>
+                  </select>
+                </label>
+                <button id="download-logo" type="button">Motif logos</button>
+                <button id="download-rank" type="button">Bar plot</button>
+                <button id="download-volcano" type="button">Volcano plot</button>
+                <button id="download-aggregate" class="aggregate-only" type="button">Aggregate plots</button>
+                <button id="download-panel" type="button">Combined panel</button>
+                <button id="download-tsv" type="button">Comparison TSV</button>
+                <a
+                  id="download-all"
+                  class="button-link"
+                  href="data/all_pairwise_results.tsv.gz"
+                  download
+                  >All results</a
+                >
               </div>
             </section>
 

--- a/docs/ENCODE-Cancer-Cell-lines-Footprinting/styles.css
+++ b/docs/ENCODE-Cancer-Cell-lines-Footprinting/styles.css
@@ -168,6 +168,8 @@ a {
   min-width: 0;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 .section-title {
   margin: 0 0 5px;

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -19,8 +19,8 @@ starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 Download the app for your computer, then open it. The GUI starts in your
 browser.
 
-[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc10/fp-tools-gui-windows-x64.exe){ .md-button }
-[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc10/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
+[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc11/fp-tools-gui-windows-x64.exe){ .md-button }
+[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc11/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
 The preview apps are unsigned. Windows may ask you to confirm the download. On
 macOS, Control-click the app and choose **Open** the first time.

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc10
+#      python -m pip install fp-tools-bio==0.2.0rc11
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc10}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc11}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc10</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc11</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc10"
+version = "0.2.0rc11"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -147,7 +147,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc10"
+version = "0.2.0rc11"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/scripts/audit_desktop_gui.py
+++ b/scripts/audit_desktop_gui.py
@@ -267,6 +267,127 @@ def _audit_sidebar_navigation(
         context.close()
 
 
+def _audit_validation_layout(
+    browser,
+    base_url: str,
+    page_name: str,
+    width: int,
+    height: int,
+    device_scale_factor: float,
+    output: Path,
+    capture_screenshots: bool,
+) -> None:
+    """Keep long validation paths and YAML previews inside the Run column."""
+
+    context = browser.new_context(
+        viewport={"width": width, "height": height},
+        device_scale_factor=device_scale_factor,
+    )
+    page = context.new_page()
+    try:
+        initial_page = "sc-footprinting" if page_name == "Config" else page_name
+        page.goto(
+            f"{base_url}/?page={urllib.parse.quote(initial_page)}",
+            wait_until="domcontentloaded",
+        )
+        page.locator(".fp-page-heading h1", has_text=initial_page).wait_for(timeout=60_000)
+        page.locator(".fp-validation-errors").first.wait_for(timeout=30_000)
+        if page_name == "Config":
+            page.get_by_role("button", name="Config", exact=True).click(force=True)
+            page.locator(".fp-page-heading h1", has_text="Config").wait_for(timeout=60_000)
+            page.locator(".fp-validation-errors").first.wait_for(timeout=30_000)
+
+        errors = page.locator(".fp-validation-errors").first
+        run_column = errors.locator(
+            "xpath=ancestor::*[@data-testid='stColumn'][1]"
+        )
+        main = page.locator("[data-testid='stMain']")
+        measurements = errors.evaluate(
+            """element => {
+              const runColumn = element.closest('[data-testid="stColumn"]');
+              const main = element.closest('[data-testid="stMain"]');
+              const columnBox = runColumn.getBoundingClientRect();
+              return {
+                mainOverflow: main.scrollWidth - main.clientWidth,
+                listOverflow: element.scrollWidth - element.clientWidth,
+                outsideLeft: columnBox.left - element.getBoundingClientRect().left,
+                outsideRight: element.getBoundingClientRect().right - columnBox.right,
+                itemOverflow: [...element.querySelectorAll('li')].map(
+                  item => item.scrollWidth - item.clientWidth
+                ),
+                itemOutside: [...element.querySelectorAll('li')].map(item => {
+                  const box = item.getBoundingClientRect();
+                  return Math.max(columnBox.left - box.left, box.right - columnBox.right);
+                })
+              };
+            }"""
+        )
+        failures = []
+        if measurements["mainOverflow"] > 1:
+            failures.append(f"main pane overflows by {measurements['mainOverflow']:.1f}px")
+        if measurements["listOverflow"] > 1:
+            failures.append(f"validation list overflows by {measurements['listOverflow']:.1f}px")
+        if max(measurements["outsideLeft"], measurements["outsideRight"]) > 1:
+            failures.append("validation list extends outside the Run column")
+        if any(value > 1 for value in measurements["itemOverflow"]):
+            failures.append("a validation message has horizontal overflow")
+        if any(value > 1 for value in measurements["itemOutside"]):
+            failures.append("a validation message extends outside the Run column")
+        if not page.get_by_role("button", name="Start run", exact=True).is_disabled():
+            failures.append("Start run is enabled for an invalid configuration")
+
+        page.get_by_text("Preview runnable YAML", exact=True).evaluate(
+            "element => { element.closest('details').open = true; }"
+        )
+        code = run_column.locator("[data-testid='stCode'], [data-testid='stCodeBlock']").first
+        code.wait_for(timeout=30_000)
+        code_metrics = code.evaluate(
+            """element => {
+              const main = element.closest('[data-testid="stMain"]');
+              const column = element.closest('[data-testid="stColumn"]');
+              const box = element.getBoundingClientRect();
+              const columnBox = column.getBoundingClientRect();
+              const pre = element.querySelector('pre');
+              return {
+                mainOverflow: main.scrollWidth - main.clientWidth,
+                outside: Math.max(columnBox.left - box.left, box.right - columnBox.right),
+                localOverflow: pre ? pre.scrollWidth - pre.clientWidth : 0,
+                preOverflowX: pre ? getComputedStyle(pre).overflowX : ''
+              };
+            }"""
+        )
+        if code_metrics["mainOverflow"] > 1:
+            failures.append("YAML preview creates main-pane overflow")
+        if code_metrics["outside"] > 1:
+            failures.append("YAML preview extends outside the Run column")
+        if code_metrics["localOverflow"] > 1 and code_metrics["preOverflowX"] not in {
+            "auto",
+            "scroll",
+        }:
+            failures.append("wide YAML does not scroll within its own code block")
+
+        if failures:
+            screenshot = output / f"validation-{page_name}-{width}-failure.png"
+            if capture_screenshots:
+                page.screenshot(
+                    path=str(screenshot),
+                    full_page=False,
+                    animations="disabled",
+                    timeout=30_000,
+                )
+            raise RuntimeError(
+                f"Validation-layout audit failed for {page_name} at {width}px: "
+                + "; ".join(failures)
+            )
+        print(
+            f"Audited validation layout for {page_name} at {width}x{height}, "
+            f"DPR {device_scale_factor}",
+            flush=True,
+        )
+    finally:
+        context.close()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("executable")
@@ -334,6 +455,27 @@ def main() -> int:
                             output,
                             not args.skip_screenshots,
                         )
+
+                    for width, height, scale in (
+                        (1920, 1080, 2.0),
+                        (1280, 720, 1.25),
+                    ):
+                        for page_name in (
+                            "sc-footprinting",
+                            "pseudobulk-fragments",
+                            "find-signature-fp",
+                            "Config",
+                        ):
+                            _audit_validation_layout(
+                                browser,
+                                base_url,
+                                page_name,
+                                width,
+                                height,
+                                scale,
+                                output,
+                                not args.skip_screenshots,
+                            )
 
                     context = browser.new_context(viewport={"width": 1280, "height": 720})
                     page = context.new_page()

--- a/scripts/audit_report_plot_controls.py
+++ b/scripts/audit_report_plot_controls.py
@@ -4,16 +4,149 @@
 from __future__ import annotations
 
 import argparse
+import functools
+import http.server
 import re
+import tempfile
+import threading
 import xml.etree.ElementTree as ET
+from contextlib import contextmanager
 from pathlib import Path
+from urllib.parse import quote
 
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import expect, sync_playwright
+
+from fp_tools.tools.review_multi_comparisons import write_review_html
+
+
+def fixture_payload(include_aggregates: bool) -> dict:
+    aggregate_motifs = []
+    if include_aggregates:
+        aggregate_motifs = [
+            {
+                "prefix": "JUN_M1",
+                "name": "JUN",
+                "motif_id": "M1",
+                "conditions": [
+                    {
+                        "name": "KD",
+                        "samples": [
+                            {"name": "KD_1", "profile": [0.1, 0.2, 0.1]},
+                            {"name": "KD_2", "profile": [0.12, 0.23, 0.11]},
+                        ],
+                    },
+                    {
+                        "name": "P",
+                        "samples": [
+                            {"name": "P_1", "profile": [0.2, 0.1, 0.2]},
+                            {"name": "P_2", "profile": [0.21, 0.12, 0.22]},
+                        ],
+                    },
+                ],
+            }
+        ]
+    return {
+        "conditions": ["KD", "P"],
+        "groups": ["KD_up", "P_up", "n.s."],
+        "colors": {"KD_up": "#dc2626", "P_up": "#2563eb", "n.s.": "#8a94a6"},
+        "change_label": "Differential footprint score",
+        "points": [
+            {
+                "prefix": "JUN_M1",
+                "name": "JUN",
+                "motif_id": "M1",
+                "group": "KD_up",
+                "change": 0.8,
+                "pvalue": 1e-10,
+                "fdr": 1e-8,
+                "neglog10p": 10.0,
+            },
+            {
+                "prefix": "FOS_M2",
+                "name": "FOS",
+                "motif_id": "M2",
+                "group": "P_up",
+                "change": -0.8,
+                "pvalue": 1e-12,
+                "fdr": 1e-10,
+                "neglog10p": 12.0,
+            },
+        ],
+        "motif_matrices": {},
+        "logos": {},
+        "aggregate": {"x": [-1, 0, 1], "motifs": aggregate_motifs},
+    }
+
+
+def write_fixtures(output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reports = []
+    for name, include_aggregates in (
+        ("with-aggregates.html", True),
+        ("aggregate-free.html", False),
+    ):
+        report = output_dir / name
+        write_review_html(
+            {
+                "schema": "fp-tools.review-multi-comparisons.v1",
+                "title": "Plot-control browser audit",
+                "comparisons": [
+                    {"label": "KD vs P", "payload": fixture_payload(include_aggregates)}
+                ],
+            },
+            report,
+        )
+        reports.append(report)
+    return reports
+
+
+class QuietRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@contextmanager
+def serve_report(report: Path):
+    handler = functools.partial(QuietRequestHandler, directory=str(report.parent))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        yield f"http://127.0.0.1:{port}/{quote(report.name)}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def click_control(page, locator) -> None:
+    target = locator
+    if locator.get_attribute("role") == "switch":
+        target = locator.locator("xpath=ancestor::label[1]")
+    target.evaluate("element => element.scrollIntoView({block: 'center', inline: 'nearest'})")
+    expect(target).to_be_visible()
+    box = locator.bounding_box()
+    if not box:
+        raise AssertionError("Report control has no clickable browser box")
+    x = box["x"] + box["width"] / 2
+    y = box["y"] + box["height"] / 2
+    hit = locator.evaluate(
+        """(element, point) => {
+          const target = document.elementFromPoint(point.x, point.y);
+          return Boolean(target && (target === element || element.contains(target) || target.closest('label')?.contains(element)));
+        }""",
+        {"x": x, "y": y},
+    )
+    if not hit:
+        raise AssertionError("Report control center is clipped or covered")
+    page.mouse.click(x, y)
 
 
 def downloaded_svg(page, selector: str) -> str:
+    control = page.locator(selector)
     with page.expect_download() as pending:
-        page.locator(selector).click()
+        click_control(page, control)
     return Path(pending.value.path()).read_text(encoding="utf-8")
 
 
@@ -67,6 +200,12 @@ def audit_svg_exports(page, report: Path, expected_comparison: str) -> None:
     cells = [
         node for node in root.iter() if node.get("data-export-cell") is not None
     ]
+    expected_cells = 3 if page.locator("#download-aggregate").is_visible() else 2
+    if len(cells) != expected_cells:
+        raise AssertionError(
+            f"{report}: combined export contains {len(cells)} audited cells; "
+            f"expected {expected_cells}"
+        )
     for cell in cells:
         source_width = float(cell.get("data-source-width", "nan"))
         source_height = float(cell.get("data-source-height", "nan"))
@@ -85,23 +224,27 @@ def audit_svg_exports(page, report: Path, expected_comparison: str) -> None:
             raise AssertionError(f"{report}: exported subplot retains an opaque background")
 
 
-def audit_report(page, report: Path, screenshot: Path | None = None) -> None:
+def audit_report(page, report: Path, url: str, screenshot: Path | None = None) -> None:
     errors: list[str] = []
     page.on("pageerror", lambda error: errors.append(str(error)))
     page.on(
         "console",
         lambda message: errors.append(message.text) if message.type == "error" else None,
     )
-    page.goto(report.resolve().as_uri(), wait_until="load")
+    page.goto(url, wait_until="load")
     page.wait_for_selector("#rank-sort-toggle")
     page.wait_for_function(
         "document.querySelectorAll('svg.rank-svg,#rank-chart .rank-bar').length > 0"
     )
 
-    comparison_control = page.locator(
-        "[data-comparison-slot],#comparison-selector"
-    ).first
-    expected_comparison = comparison_control.locator("option:checked").inner_text()
+    comparison_control = page.locator("#comparison-selector")
+    if page.locator("#comparison-selector-control").is_visible():
+        comparison_control.locator("option").first.wait_for(state="attached", timeout=60_000)
+        expected_comparison = comparison_control.locator("option:checked").inner_text()
+    else:
+        first = page.locator("#condition-1 option:checked").inner_text()
+        second = page.locator("#condition-2 option:checked").inner_text()
+        expected_comparison = f"{first} vs {second}"
     volcano_text = page.locator("svg.volcano-svg,#chart").first.text_content() or ""
     if expected_comparison not in volcano_text:
         raise AssertionError(
@@ -110,6 +253,9 @@ def audit_report(page, report: Path, screenshot: Path | None = None) -> None:
         )
 
     toggle = page.locator("#rank-sort-toggle")
+    click_box = toggle.bounding_box()
+    if not click_box or click_box["height"] < 12:
+        raise AssertionError(f"{report}: rank switch is clipped: {click_box}")
     if toggle.is_checked():
         raise AssertionError(f"{report}: waterfall must default to differential score")
     initial_fills = page.locator(".rank-bar").evaluate_all(
@@ -169,8 +315,8 @@ def audit_report(page, report: Path, screenshot: Path | None = None) -> None:
             f"{report}: volcano resized after row/panel controls: "
             f"{initial_box} -> {resized_box}"
         )
-    toggle.check()
-    page.wait_for_timeout(50)
+    click_control(page, toggle)
+    expect(toggle).to_be_checked()
     rank_text = page.locator("svg.rank-svg,#rank-chart").all_text_contents()
     if not rank_text or not all("Signed -log10(p-value)" in text or "Signed −log10(p-value)" in text for text in rank_text):
         raise AssertionError(f"{report}: significance-ranked axis is missing")
@@ -205,8 +351,8 @@ def audit_report(page, report: Path, screenshot: Path | None = None) -> None:
 
     audit_svg_exports(page, report, expected_comparison)
 
-    toggle.uncheck()
-    page.wait_for_timeout(50)
+    click_control(page, toggle)
+    expect(toggle).not_to_be_checked()
     if screenshot:
         screenshot.parent.mkdir(parents=True, exist_ok=True)
         page.screenshot(path=str(screenshot), full_page=True)
@@ -216,24 +362,39 @@ def audit_report(page, report: Path, screenshot: Path | None = None) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("html", nargs="+", type=Path)
+    parser.add_argument("html", nargs="*", type=Path)
+    parser.add_argument(
+        "--fixture-dir",
+        type=Path,
+        help="Generate and audit deterministic aggregate and aggregate-free reports here.",
+    )
     parser.add_argument("--screenshot-dir", type=Path)
     args = parser.parse_args()
+    reports = [path.resolve() for path in args.html]
+    temporary_fixture = None
+    if args.fixture_dir:
+        reports.extend(write_fixtures(args.fixture_dir.resolve()))
+    elif not reports:
+        temporary_fixture = tempfile.TemporaryDirectory(prefix="fp-tools-report-audit-")
+        reports.extend(write_fixtures(Path(temporary_fixture.name)))
     with sync_playwright() as playwright:
         browser = playwright.chromium.launch(headless=True)
         try:
-            for report in args.html:
+            for report in reports:
                 page = browser.new_page(viewport={"width": 1800, "height": 1050})
                 screenshot = (
                     args.screenshot_dir / f"{report.stem}_plot_controls.png"
                     if args.screenshot_dir
                     else None
                 )
-                audit_report(page, report, screenshot)
+                with serve_report(report) as url:
+                    audit_report(page, report, url, screenshot)
                 page.close()
                 print(f"PASS {report}")
         finally:
             browser.close()
+    if temporary_fixture is not None:
+        temporary_fixture.cleanup()
     return 0
 
 

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc10"
+__version__ = "0.2.0rc11"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/gui_app.py
+++ b/src/fp_tools/gui_app.py
@@ -470,6 +470,27 @@ def _apply_page_style() -> None:
             padding-left: clamp(1rem, 1.7vw, 2.2rem);
             padding-right: clamp(1rem, 1.7vw, 2.2rem);
         }
+        [data-testid="stMain"],
+        [data-testid="stMain"] [data-testid="stMainBlockContainer"],
+        [data-testid="stMain"] [data-testid="stHorizontalBlock"],
+        [data-testid="stMain"] [data-testid="stColumn"],
+        [data-testid="stMain"] [data-testid="stColumn"] > [data-testid="stVerticalBlock"],
+        [data-testid="stMain"] [data-testid="stElementContainer"] {
+            min-width: 0 !important;
+            max-width: 100% !important;
+        }
+        [data-testid="stMain"] [data-testid="stCode"],
+        [data-testid="stMain"] [data-testid="stCodeBlock"] {
+            min-width: 0 !important;
+            max-width: 100% !important;
+            overflow: hidden !important;
+        }
+        [data-testid="stMain"] [data-testid="stCode"] pre,
+        [data-testid="stMain"] [data-testid="stCodeBlock"] pre {
+            min-width: 0 !important;
+            max-width: 100% !important;
+            overflow-x: auto !important;
+        }
         .fp-sidebar-brand {
             background: #101d33;
             color: #ffffff;
@@ -696,6 +717,23 @@ def _apply_page_style() -> None:
             overflow-wrap: normal;
             word-break: normal;
             hyphens: none;
+        }
+        .fp-validation-errors {
+            box-sizing: border-box;
+            width: 100%;
+            min-width: 0;
+            max-width: 100%;
+            margin: 0.35rem 0 0.55rem;
+            padding-left: 1.2rem;
+            white-space: normal;
+        }
+        .fp-validation-errors li {
+            min-width: 0;
+            max-width: 100%;
+            margin: 0.24rem 0;
+            overflow-wrap: anywhere;
+            word-break: break-word;
+            white-space: normal;
         }
         .fp-tutorial-panel {
             background: #eaf2ff;
@@ -1466,6 +1504,14 @@ def _render_page_loader(tool: str) -> None:
             _set_config(normalize_config(load_yaml_config(path_text.strip())))
 
 
+def _validation_errors_markup(messages: list[str]) -> str:
+    items = "".join(f"<li>{escape(message)}</li>" for message in messages)
+    return (
+        '<ul class="fp-validation-errors" '
+        f'aria-label="Configuration validation errors">{items}</ul>'
+    )
+
+
 def _render_run_controls(run_dir: Path, label: str) -> None:
     normalized = normalize_config(st.session_state.current_config)
     validation_errors = validate_gui_config(normalized)
@@ -1487,8 +1533,10 @@ def _render_run_controls(run_dir: Path, label: str) -> None:
         )
         if validation_errors:
             st.error("Config needs fixes before launch.")
-            for message in validation_errors:
-                st.write(f"- {message}")
+            st.markdown(
+                _validation_errors_markup(validation_errors),
+                unsafe_allow_html=True,
+            )
         else:
             st.success("Config is ready to run.")
         with st.expander("Preview runnable YAML", expanded=False):

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc10",
-  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc10",
+  "runtime_version": "0.2.0rc11",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc11",
   "components": {
     "core": {
       "commands": [
@@ -37,23 +37,23 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc10-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc10-linux-x86_64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc11-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc11-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc10-linux-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-linux-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc10-linux-arm64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc11-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc11-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-macos-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc10-macos-arm64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc10-linux-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc11-linux-x86_64.tar.gz"}
     }
   }
 }

--- a/src/fp_tools/resources/static_browser/app.js
+++ b/src/fp_tools/resources/static_browser/app.js
@@ -1375,7 +1375,7 @@ function combinedPanelSvg() {
   volcano.querySelector("style")?.remove();
   if (!state.hasAggregates) {
     const totalWidth = rankDisplayWidth + volcanoSize + gap;
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g transform="scale(${rankScale})">${rank.innerHTML}</g><g transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g></svg>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g data-export-cell="rank" data-source-width="${rankWidth}" data-source-height="${rankHeight}" data-cell-width="${rankDisplayWidth}" data-cell-height="${panelHeight}" data-scale="${rankScale}" transform="scale(${rankScale})">${rank.innerHTML}</g><g data-export-cell="volcano" data-source-width="${volcanoSize}" data-source-height="${volcanoSize}" data-cell-width="${volcanoSize}" data-cell-height="${panelHeight}" data-scale="1" transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g></svg>`;
   }
   const aggregate = aggregateGridSvg(),
     aggregateDocument = new DOMParser().parseFromString(
@@ -1387,7 +1387,8 @@ function combinedPanelSvg() {
     aggregateWidth = (aggregateBox.width || 600) * aggregateScale,
     totalWidth = rankDisplayWidth + volcanoSize + aggregateWidth + gap * 2;
   aggregateDocument.querySelector("style")?.remove();
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g transform="scale(${rankScale})">${rank.innerHTML}</g><g transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g><g transform="translate(${rankDisplayWidth + volcanoSize + gap * 2},0) scale(${aggregateScale})">${aggregateDocument.innerHTML}</g></svg>`;
+  aggregateDocument.querySelector(":scope > rect")?.remove();
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalWidth} ${panelHeight}" font-family="Helvetica,Arial,sans-serif"><style>${plotSvgStyle}</style><rect width="100%" height="100%" fill="#fff"/><g data-export-cell="rank" data-source-width="${rankWidth}" data-source-height="${rankHeight}" data-cell-width="${rankDisplayWidth}" data-cell-height="${panelHeight}" data-scale="${rankScale}" transform="scale(${rankScale})">${rank.innerHTML}</g><g data-export-cell="volcano" data-source-width="${volcanoSize}" data-source-height="${volcanoSize}" data-cell-width="${volcanoSize}" data-cell-height="${panelHeight}" data-scale="1" transform="translate(${rankDisplayWidth + gap},0)">${volcano.innerHTML}</g><g data-export-cell="aggregate" data-source-width="${aggregateBox.width || 600}" data-source-height="${aggregateBox.height || 600}" data-cell-width="${aggregateWidth}" data-cell-height="${panelHeight}" data-scale="${aggregateScale}" transform="translate(${rankDisplayWidth + volcanoSize + gap * 2},0) scale(${aggregateScale})">${aggregateDocument.innerHTML}</g></svg>`;
 }
 
 function svgDimensions(svg) {

--- a/src/fp_tools/resources/static_browser/index.html
+++ b/src/fp_tools/resources/static_browser/index.html
@@ -57,31 +57,7 @@
           <summary>Show/Hide</summary>
           <div class="options-grid">
             <section class="option-col options-actions">
-              <p class="section-title">Export</p>
-              <div class="card export-stack">
-                <label class="format-row"
-                  >Format
-                  <select id="figure-format" aria-label="Figure export format">
-                    <option value="svg">Editable SVG</option>
-                    <option value="png">PNG</option>
-                    <option value="pdf">Print / PDF</option>
-                  </select>
-                </label>
-                <button id="download-logo" type="button">Motif logos</button>
-                <button id="download-rank" type="button">Bar plot</button>
-                <button id="download-volcano" type="button">Volcano plot</button>
-                <button id="download-aggregate" class="aggregate-only" type="button">Aggregate plots</button>
-                <button id="download-panel" type="button">Combined panel</button>
-                <button id="download-tsv" type="button">Comparison TSV</button>
-                <a
-                  id="download-all"
-                  class="button-link"
-                  href="data/all_pairwise_results.tsv.gz"
-                  download
-                  >All results</a
-                >
-              </div>
-              <p class="section-title group-title">Groups</p>
+              <p class="section-title">Groups</p>
               <div class="card control-stack">
                 <div id="color-controls" class="color-controls"></div>
                 <label class="rank-sort-control" title="Switch the waterfall ranking metric">
@@ -125,6 +101,30 @@
                     title="Comma-separated TF names, motif IDs, or output prefixes"
                   />
                 </label>
+              </div>
+              <p class="section-title group-title">Export</p>
+              <div class="card export-stack">
+                <label class="format-row"
+                  >Format
+                  <select id="figure-format" aria-label="Figure export format">
+                    <option value="svg">Editable SVG</option>
+                    <option value="png">PNG</option>
+                    <option value="pdf">Print / PDF</option>
+                  </select>
+                </label>
+                <button id="download-logo" type="button">Motif logos</button>
+                <button id="download-rank" type="button">Bar plot</button>
+                <button id="download-volcano" type="button">Volcano plot</button>
+                <button id="download-aggregate" class="aggregate-only" type="button">Aggregate plots</button>
+                <button id="download-panel" type="button">Combined panel</button>
+                <button id="download-tsv" type="button">Comparison TSV</button>
+                <a
+                  id="download-all"
+                  class="button-link"
+                  href="data/all_pairwise_results.tsv.gz"
+                  download
+                  >All results</a
+                >
               </div>
             </section>
 

--- a/src/fp_tools/resources/static_browser/styles.css
+++ b/src/fp_tools/resources/static_browser/styles.css
@@ -171,6 +171,8 @@ a {
   min-width: 0;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 .section-title {
   margin: 0 0 5px;

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -12,6 +12,7 @@ from fp_tools.gui_app import (
     _all_example_files,
     _format_extra_args,
     _parse_extra_args,
+    _validation_errors_markup,
 )
 from fp_tools.cli_gui import _access_urls, _startup_messages
 from fp_tools.utils.subprocess_commands import (
@@ -22,6 +23,19 @@ from fp_tools.utils.subprocess_commands import (
 
 
 class GuiLauncherTests(unittest.TestCase):
+    def test_validation_error_markup_wraps_paths_and_escapes_html(self):
+        markup = _validation_errors_markup(
+            [
+                r"Missing fragments: C:\Users\Researcher\a very long project\inputs\cells.fragments.tsv.gz",
+                "Invalid <sample> & comparison",
+            ]
+        )
+
+        self.assertIn('class="fp-validation-errors"', markup)
+        self.assertEqual(markup.count("<li>"), 2)
+        self.assertIn("&lt;sample&gt; &amp; comparison", markup)
+        self.assertNotIn("<sample>", markup)
+
     def test_run_control_state_tracks_validation_and_keeps_launch_guard(self):
         normalized = {
             "version": 1,

--- a/tests/test_report_plot_controls.py
+++ b/tests/test_report_plot_controls.py
@@ -65,6 +65,24 @@ class ReportPlotControlsTest(unittest.TestCase):
             '<rect width="${width}" height="${height}" fill="#fff"/><text x="${width / 2}" y="24"',
             app,
         )
+        self.assertEqual(app.count('data-export-cell="'), 5)
+        for attribute in (
+            "data-source-width",
+            "data-source-height",
+            "data-cell-width",
+            "data-cell-height",
+            "data-scale",
+        ):
+            self.assertIn(attribute, app)
+        self.assertIn('querySelector(":scope > rect")?.remove()', app)
+
+    def test_controls_precede_exports_in_the_scrollable_action_column(self):
+        document = (RESOURCE_ROOT / "index.html").read_text(encoding="utf-8")
+        actions = document.split('<section class="option-col options-actions">', 1)[1].split(
+            "</section>", 1
+        )[0]
+
+        self.assertLess(actions.index(">Groups<"), actions.index(">Export<"))
 
     def test_bundle_and_embedded_reports_share_plot_control_code(self):
         review = {


### PR DESCRIPTION
## Summary
- contain and wrap long GUI validation paths and keep YAML overflow local to the Run panel
- add frozen Windows/macOS browser regressions for all four affected pages at 1920×1080 and 1280×720
- keep report plot controls visible and mouse-accessible, and validate combined SVG subplot bounds
- enforce aggregate, aggregate-free, and deployed ENCODE browser audits in Docs CI
- prepare release candidate 0.2.0rc11

## Verification
- 402 passed, 1 skipped in the full test suite
- 49 passed in focused release/docs/GUI tests
- desktop GUI browser audit passed at desktop, 1280×720, and mobile widths; validation layout passed on all affected pages at both required desktop viewports
- strict MkDocs build and 32-page responsive audit passed
- aggregate, aggregate-free, and real ENCODE report browser audits passed
- package dependency check, console-script smoke tests, YAML dry-run, sdist build, and twine check passed

Fixes #46