### PR TITLE
Fix match-motifs logging and native desktop apps

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -40,9 +40,11 @@ jobs:
       - name: Install fp-tools and bundler
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --only-binary=:all: . "pyinstaller>=6.19,<7" "playwright>=1.55,<2"
+          python -m pip install --only-binary=:all: . "pyinstaller>=6.19,<7" "playwright>=1.55,<2" "PySide6>=6.8,<7"
           python -m playwright install chromium
           python -m pip check
+      - name: Build branded application icons
+        run: python scripts/build_desktop_icons.py
       - name: Build one-file desktop executable
         run: pyinstaller --clean --noconfirm packaging/desktop/fp-tools-gui.spec
       - name: Smoke-test command dispatch and GUI startup
@@ -74,9 +76,11 @@ jobs:
         run: |
           app="release/fp-tools.app"
           dmg="release/fp-tools-gui-macos-apple-silicon.dmg"
-          mkdir -p "${app}/Contents/MacOS"
+          mkdir -p "${app}/Contents/MacOS" "${app}/Contents/Resources"
           cp dist/fp-tools-gui "${app}/Contents/MacOS/fp-tools-gui"
           cp packaging/desktop/Info.plist "${app}/Contents/Info.plist"
+          cp build/desktop-icons/fp-tools.icns "${app}/Contents/Resources/fp-tools.icns"
+          plutil -lint "${app}/Contents/Info.plist"
           for attempt in 1 2 3; do
             if hdiutil create -volname "fp-tools" -srcfolder "${app}" \
               -ov -format UDZO "${dmg}"; then

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Audit responsive desktop GUI
         run: python scripts/audit_desktop_gui.py "${{ matrix.executable }}"
       - uses: actions/upload-artifact@v7
+        if: always()
         with:
           name: desktop-audit-${{ matrix.label }}
           path: desktop-gui-audit/*.png

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -73,11 +73,22 @@ jobs:
         shell: bash
         run: |
           app="release/fp-tools.app"
+          dmg="release/fp-tools-gui-macos-apple-silicon.dmg"
           mkdir -p "${app}/Contents/MacOS"
           cp dist/fp-tools-gui "${app}/Contents/MacOS/fp-tools-gui"
           cp packaging/desktop/Info.plist "${app}/Contents/Info.plist"
-          hdiutil create -volname "fp-tools" -srcfolder "${app}" \
-            -ov -format UDZO "release/fp-tools-gui-macos-apple-silicon.dmg"
+          for attempt in 1 2 3; do
+            if hdiutil create -volname "fp-tools" -srcfolder "${app}" \
+              -ov -format UDZO "${dmg}"; then
+              break
+            fi
+            if [[ "${attempt}" -eq 3 ]]; then
+              echo "hdiutil failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "hdiutil was temporarily unavailable; retrying..." >&2
+            sleep 5
+          done
           rm -rf "${app}"
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -74,15 +74,33 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          app="release/fp-tools.app"
+          stage="release/macos-dmg"
+          app="${stage}/fp-tools.app"
           dmg="release/fp-tools-gui-macos-apple-silicon.dmg"
           mkdir -p "${app}/Contents/MacOS" "${app}/Contents/Resources"
           cp dist/fp-tools-gui "${app}/Contents/MacOS/fp-tools-gui"
           cp packaging/desktop/Info.plist "${app}/Contents/Info.plist"
           cp build/desktop-icons/fp-tools.icns "${app}/Contents/Resources/fp-tools.icns"
+          cp packaging/desktop/OPEN-FIRST-macOS.txt "${stage}/OPEN-FIRST-macOS.txt"
+          ln -s /Applications "${stage}/Applications"
           plutil -lint "${app}/Contents/Info.plist"
+          codesign --force --deep --sign - "${app}"
+          codesign --verify --deep --strict --verbose=2 "${app}"
+          lipo -archs "${app}/Contents/MacOS/fp-tools-gui" | grep -qw arm64
+
+          xattr -w com.apple.quarantine "0083;00000000;GitHub;" "${app}"
+          xattr -p com.apple.quarantine "${app}" >/dev/null
+          xattr -dr com.apple.quarantine "${app}"
+          if xattr -p com.apple.quarantine "${app}" >/dev/null 2>&1; then
+            echo "The documented quarantine-removal command did not clear the app" >&2
+            exit 1
+          fi
+          "${app}/Contents/MacOS/fp-tools-gui" \
+            --fp-tools-internal-native-window-smoke \
+            --run-dir "${RUNNER_TEMP}/fp-tools-dmg-native-smoke"
+
           for attempt in 1 2 3; do
-            if hdiutil create -volname "fp-tools" -srcfolder "${app}" \
+            if hdiutil create -volname "fp-tools" -srcfolder "${stage}" \
               -ov -format UDZO "${dmg}"; then
               break
             fi
@@ -93,7 +111,17 @@ jobs:
             echo "hdiutil was temporarily unavailable; retrying..." >&2
             sleep 5
           done
-          rm -rf "${app}"
+          hdiutil verify "${dmg}"
+
+          mount_point="${RUNNER_TEMP}/fp-tools-dmg-mount"
+          mkdir -p "${mount_point}"
+          hdiutil attach -nobrowse -readonly -mountpoint "${mount_point}" "${dmg}"
+          test -d "${mount_point}/fp-tools.app"
+          test -f "${mount_point}/OPEN-FIRST-macOS.txt"
+          test -L "${mount_point}/Applications"
+          codesign --verify --deep --strict --verbose=2 "${mount_point}/fp-tools.app"
+          hdiutil detach "${mount_point}"
+          rm -rf "${stage}"
       - uses: actions/upload-artifact@v7
         with:
           name: fp-tools-gui-${{ matrix.label }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Yaoxiang
   - family-names: Yi
     given-names: Chunling
-version: 0.2.0rc11
+version: 0.2.0rc12
 license: MIT
 repository-code: "https://github.com/oncologylab/fp-tools"
 url: "https://github.com/oncologylab/fp-tools"

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -60,6 +60,10 @@ a separately planned breaking release explicitly changes the contract.
   and frozen-safe command and workflow dispatch. Every GUI starts from BAM/BAI
   plus peak BED files. Linux and Intel macOS use the browser-based Python
   package; the complete container remains available on amd64 and arm64.
+- The Apple Silicon download remains an explicitly unsigned preview. Its DMG
+  includes the same one-line quarantine-removal instruction shown on the
+  installation page, and CI verifies the ad-hoc bundle signature, ARM64
+  executable, DMG contents, quarantine removal, and native-window launch.
 - Branded GitHub and MkDocs presentation with responsive embedded report and
   GUI demos plus automated desktop/mobile browser audits.
 - Responsive GUI validation output with contained long paths and locally

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -56,9 +56,10 @@ a separately planned breaking release explicitly changes the contract.
 - A complete amd64/arm64 container with the external genomics toolchain and a
   browser GUI as its default entry point.
 - BAM-first self-contained GUI executables for Windows x64 and Apple Silicon,
-  with frozen-safe command and workflow dispatch. Every GUI starts from BAM/BAI
-  plus peak BED files. Linux and Intel macOS use the Python package; the
-  complete container remains available on amd64 and arm64.
+  with branded operating-system icons, a bundled native application window,
+  and frozen-safe command and workflow dispatch. Every GUI starts from BAM/BAI
+  plus peak BED files. Linux and Intel macOS use the browser-based Python
+  package; the complete container remains available on amd64 and arm64.
 - Branded GitHub and MkDocs presentation with responsive embedded report and
   GUI demos plus automated desktop/mobile browser audits.
 - Responsive GUI validation output with contained long paths and locally

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -1,6 +1,6 @@
 # fp-tools Development Plan
 
-Last updated: 2026-08-20
+Last updated: 2026-08-21
 
 ## Current Baseline
 
@@ -65,6 +65,8 @@ a separately planned breaking release explicitly changes the contract.
   scrolling YAML previews, verified in the native Windows and macOS audits.
 - Browser-verified plot controls and SVG exports for aggregate and
   aggregate-free reports, including explicit subplot-bound checks.
+- Command-aware logging across shared analysis engines, so `match-motifs` and
+  `diff-footprints` retain their public names in direct and wrapper-run logs.
 - A manifest-pinned, storage-conscious ENCODE workflow for 17 biological
   replicates from seven cancer cell lines. Its resumable runner uses a
   pair-specific union of released IDR-thresholded peaks, peak-q95 scaling, and

--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -68,6 +68,8 @@ a separately planned breaking release explicitly changes the contract.
   GUI demos plus automated desktop/mobile browser audits.
 - Responsive GUI validation output with contained long paths and locally
   scrolling YAML previews, verified in the native Windows and macOS audits.
+  Path messages use forced cross-platform line breaking, and failed desktop
+  audits retain screenshots as CI artifacts for diagnosis.
 - Browser-verified plot controls and SVG exports for aggregate and
   aggregate-free reports, including explicit subplot-bound checks.
 - Command-aware logging across shared analysis engines, so `match-motifs` and

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -102,8 +102,12 @@ The `Desktop bundles` workflow must produce and smoke-test a Windows x64
 executable and an unsigned Apple Silicon macOS DMG. Both artifacts must use the
 fp-tools icon and open the command-backed GUI in a native application window.
 The live checks verify the private Streamlit server, native window rendering,
-and frozen child-process dispatch. Release assets include a SHA-256 checksum
-manifest. macOS Intel and Linux users install the Python package instead.
+and frozen child-process dispatch. The Mac job must ad-hoc sign and strictly
+verify the application bundle, confirm its ARM64 executable, exercise the
+documented quarantine-removal command, verify and mount the DMG, and confirm
+that the first-launch instruction is included. Release assets include a
+SHA-256 checksum manifest. macOS Intel and Linux users install the Python
+package instead.
 
 The `Container` workflow builds and tests the complete environment on
 `linux/amd64` and `linux/arm64`, then attaches both loadable image archives and

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -99,10 +99,11 @@ python -m venv /tmp/fp-tools-pypi-smoke
 ```
 
 The `Desktop bundles` workflow must produce and smoke-test a Windows x64
-executable and an unsigned Apple Silicon macOS DMG. Its live health check verifies that the
-bundled Streamlit application starts, and its command check verifies frozen
-child-process dispatch. Release assets include a SHA-256 checksum manifest.
-macOS Intel and Linux users install the Python package instead.
+executable and an unsigned Apple Silicon macOS DMG. Both artifacts must use the
+fp-tools icon and open the command-backed GUI in a native application window.
+The live checks verify the private Streamlit server, native window rendering,
+and frozen child-process dispatch. Release assets include a SHA-256 checksum
+manifest. macOS Intel and Linux users install the Python package instead.
 
 The `Container` workflow builds and tests the complete environment on
 `linux/amd64` and `linux/arm64`, then attaches both loadable image archives and

--- a/docs/api.md
+++ b/docs/api.md
@@ -1523,6 +1523,8 @@ options:
 <div class="fp-api-card" markdown="1">
 
 Launch the browser interface for configuring and running fp-tools commands.
+The Windows and Apple Silicon desktop downloads present the same interface in
+a native fp-tools application window.
 
 Bulk GUI workflows start from coordinate-sorted BAM/BAI files and matching
 peak BED files. The GUI does not perform FASTQ-to-BAM preprocessing.
@@ -1557,8 +1559,9 @@ Files under `{run_dir}` are local run state. A saved YAML remains runnable with
 
 ## Local computer
 
-Open the desktop executable or run `fp-tools-gui`. A browser opens after the
-server is ready. If it does not, open the local URL printed in the terminal.
+Open the desktop executable to use the native application window. When using
+the Python package, run `fp-tools-gui`; a browser opens after the server is
+ready. If it does not, open the local URL printed in the terminal.
 
 ## Remote Linux server
 

--- a/docs/get-started/commands/fp-tools-gui.md
+++ b/docs/get-started/commands/fp-tools-gui.md
@@ -1,6 +1,8 @@
 # [`fp-tools-gui`](../../api.md#fp-tools-gui)
 
 Launch the browser interface for configuring and running fp-tools commands.
+The Windows and Apple Silicon desktop downloads present the same interface in
+a native fp-tools application window.
 
 Bulk GUI workflows start from coordinate-sorted BAM/BAI files and matching
 peak BED files. The GUI does not perform FASTQ-to-BAM preprocessing.
@@ -38,8 +40,9 @@ Open the [GUI Demo](../../gui.md), or see the
 
 ## Local computer
 
-Open the desktop executable or run `fp-tools-gui`. A browser opens after the
-server is ready. If it does not, open the local URL printed in the terminal.
+Open the desktop executable to use the native application window. When using
+the Python package, run `fp-tools-gui`; a browser opens after the server is
+ready. If it does not, open the local URL printed in the terminal.
 
 ## Remote Linux server
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -19,8 +19,8 @@ starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 Download the app for your computer, then open it. The GUI starts in your
 browser.
 
-[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc11/fp-tools-gui-windows-x64.exe){ .md-button }
-[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc11/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
+[Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12/fp-tools-gui-windows-x64.exe){ .md-button }
+[Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
 The preview apps are unsigned. Windows may ask you to confirm the download. On
 macOS, Control-click the app and choose **Open** the first time.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -22,8 +22,15 @@ application window; no browser or Python installation is required.
 [Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12/fp-tools-gui-windows-x64.exe){ .md-button }
 [Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
 
-The preview apps are unsigned. Windows may ask you to confirm the download. On
-macOS, Control-click the app and choose **Open** the first time.
+Windows may ask you to confirm the unsigned preview download. For the unsigned
+Mac preview, drag `fp-tools.app` to Applications and run this once in Terminal:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/fp-tools.app && open /Applications/fp-tools.app
+```
+
+Use this command only for fp-tools downloaded from the official OncologyLab
+GitHub release page.
 
 Optional de novo motif discovery prepares its external tools on first use.
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -16,8 +16,8 @@ starts from coordinate-sorted BAM/BAI files and matching peak BED files.
 
 ## Desktop app
 
-Download the app for your computer, then open it. The GUI starts in your
-browser.
+Download the app for your computer, then open it. fp-tools opens in its own
+application window; no browser or Python installation is required.
 
 [Download for Windows](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12/fp-tools-gui-windows-x64.exe){ .md-button }
 [Download for Apple silicon](https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12/fp-tools-gui-macos-apple-silicon.dmg){ .md-button }
@@ -36,7 +36,7 @@ python -m pip install --upgrade --pre fp-tools-bio
 fp-tools-gui
 ```
 
-The GUI normally opens automatically. If it does not, open
+The Python-package GUI normally opens in your browser. If it does not, open
 `http://127.0.0.1:8891`.
 
 On Windows, use `py` instead of `python` if needed.

--- a/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
+++ b/examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 #
 # Before running on a new server:
 # 1. Install fp-tools:
-#      python -m pip install fp-tools-bio==0.2.0rc11
+#      python -m pip install fp-tools-bio==0.2.0rc12
 #
 # 2. Prepare raw data under RAW:
 #      RAW/ATAC_Nutrients_hg38_*.txt
@@ -37,7 +37,7 @@ RAW="${RAW:-$ROOT/data/public/raw/nutrient_project}"
 PROJECT="${PROJECT:-$ROOT/data/public/processed/nutrient_project_ctrl_vs_10fbs}"
 REF_ROOT="${REF_ROOT:-$RAW/references}"
 CORES="${CORES:-$(nproc)}"
-VERSION="${FP_TOOLS_VERSION:-0.2.0rc11}"
+VERSION="${FP_TOOLS_VERSION:-0.2.0rc12}"
 MOTIF_DB="${MOTIF_DB:-jaspar2026_vertebrates}"
 
 if [[ -d "$ROOT/.venv/bin" ]]; then

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -5,6 +5,7 @@
   <key>CFBundleDisplayName</key><string>fp-tools</string>
   <key>CFBundleExecutable</key><string>fp-tools-gui</string>
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
+  <key>CFBundleIconFile</key><string>fp-tools.icns</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleShortVersionString</key><string>0.2.0rc12</string>

--- a/packaging/desktop/Info.plist
+++ b/packaging/desktop/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleIdentifier</key><string>org.oncologylab.fp-tools</string>
   <key>CFBundleName</key><string>fp-tools</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0rc11</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0rc12</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>

--- a/packaging/desktop/OPEN-FIRST-macOS.txt
+++ b/packaging/desktop/OPEN-FIRST-macOS.txt
@@ -1,0 +1,7 @@
+fp-tools for Apple silicon (unsigned preview)
+
+Drag fp-tools.app to Applications, then run once in Terminal:
+
+xattr -dr com.apple.quarantine /Applications/fp-tools.app && open /Applications/fp-tools.app
+
+Use this only for fp-tools downloaded from https://github.com/oncologylab/fp-tools/releases

--- a/packaging/desktop/fp-tools-gui.spec
+++ b/packaging/desktop/fp-tools-gui.spec
@@ -3,11 +3,16 @@
 
 from importlib.util import find_spec
 from pathlib import Path
+import sys
 
 from PyInstaller.utils.hooks import collect_all, collect_data_files, copy_metadata
 
 
 root = Path.cwd().resolve()
+icon_suffix = ".ico" if sys.platform == "win32" else ".icns"
+icon_path = root / "build" / "desktop-icons" / f"fp-tools{icon_suffix}"
+if not icon_path.is_file():
+    raise RuntimeError(f"Desktop icon has not been built: {icon_path}")
 datas = []
 binaries = []
 hiddenimports = []
@@ -52,6 +57,12 @@ hiddenimports = [
 # Streamlit executes the application from a source path.  Keeping this source
 # file as data is intentional even though the module is also frozen.
 datas.append((str(root / "src" / "fp_tools" / "gui_app.py"), "fp_tools"))
+datas.append(
+    (
+        str(root / "docs" / "assets" / "fp_tools_logo_icon_1024.png"),
+        "fp_tools/resources",
+    )
+)
 
 analysis = Analysis(
     [str(root / "packaging" / "desktop" / "launcher.py")],
@@ -92,5 +103,7 @@ executable = EXE(
     strip=False,
     upx=False,
     console=True,
+    hide_console="hide-early",
+    icon=str(icon_path),
     disable_windowed_traceback=False,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fp-tools-bio"
-version = "0.2.0rc11"
+version = "0.2.0rc12"
 description = "Standalone footprint tools with vendored Cython internals"
 readme = "README.md"
 license = "MIT"
@@ -147,7 +147,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 # --- Poetry mirror of the important bits so `poetry build` works too ---
 [tool.poetry]
 name = "fp-tools-bio"
-version = "0.2.0rc11"
+version = "0.2.0rc12"
 description = "Standalone footprint tools with vendored Cython internals"
 authors = ["Yaoxiang Li"]
 readme = "README.md"

--- a/scripts/audit_desktop_gui.py
+++ b/scripts/audit_desktop_gui.py
@@ -410,7 +410,15 @@ def main() -> int:
         run_dir = workdir_path / "runs"
         runtime_cache = workdir_path / "runtime-cache"
         process = subprocess.Popen(
-            [str(executable), "--no-browser", "--port", str(port), "--run-dir", str(run_dir)],
+            [
+                str(executable),
+                "--fp-tools-internal-gui-server",
+                "--port",
+                str(port),
+                "--run-dir",
+                str(run_dir),
+                "--no-browser",
+            ],
             cwd=workdir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/scripts/build_desktop_icons.py
+++ b/scripts/build_desktop_icons.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Build native desktop icon files from the canonical fp-tools logo."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from PIL import Image
+
+
+def build_icons(source: Path, output_dir: Path) -> tuple[Path, Path]:
+    """Write multi-resolution Windows ICO and macOS ICNS assets."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with Image.open(source) as opened:
+        logo = opened.convert("RGBA")
+        if logo.width != logo.height:
+            raise ValueError("Desktop icon source must be square")
+        ico_path = output_dir / "fp-tools.ico"
+        icns_path = output_dir / "fp-tools.icns"
+        logo.save(
+            ico_path,
+            format="ICO",
+            sizes=[
+                (16, 16),
+                (24, 24),
+                (32, 32),
+                (48, 48),
+                (64, 64),
+                (128, 128),
+                (256, 256),
+            ],
+        )
+        logo.save(icns_path, format="ICNS")
+    return ico_path, icns_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path("docs/assets/fp_tools_logo_icon_1024.png"),
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("build/desktop-icons"))
+    args = parser.parse_args()
+    ico_path, icns_path = build_icons(args.source, args.output_dir)
+    print(ico_path)
+    print(icns_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_desktop_bundle.py
+++ b/scripts/smoke_desktop_bundle.py
@@ -150,7 +150,15 @@ def main() -> int:
 
         port = free_port()
         process = subprocess.Popen(
-            [str(executable), "--no-browser", "--port", str(port), "--run-dir", run_dir],
+            [
+                str(executable),
+                "--fp-tools-internal-gui-server",
+                "--port",
+                str(port),
+                "--run-dir",
+                run_dir,
+                "--no-browser",
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -161,6 +169,7 @@ def main() -> int:
         try:
             deadline = time.monotonic() + args.timeout
             last_error: Exception | None = None
+            ready = False
             while time.monotonic() < deadline:
                 if process.poll() is not None:
                     output = process.stdout.read() if process.stdout else ""
@@ -169,15 +178,42 @@ def main() -> int:
                     with urllib.request.urlopen(f"http://127.0.0.1:{port}/_stcore/health", timeout=2) as response:
                         if response.status == 200:
                             print(f"Desktop GUI ready on port {port}")
-                            return 0
+                            ready = True
+                            break
                 except Exception as exc:  # startup polling
                     last_error = exc
                     time.sleep(0.5)
-            raise SystemExit(f"GUI did not become ready within {args.timeout:g} seconds: {last_error}")
+            if not ready:
+                raise SystemExit(f"GUI did not become ready within {args.timeout:g} seconds: {last_error}")
         finally:
             output = stop_process_tree(process)
             if process.returncode not in (0, -15, 1):
                 print(output)
+
+        native_run = subprocess.run(
+            [
+                str(executable),
+                "--fp-tools-internal-native-window-smoke",
+                "--run-dir",
+                str(run_path / "native-window"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=max(args.timeout, 150.0),
+            cwd=run_dir,
+            env={
+                **os.environ,
+                "STREAMLIT_BROWSER_GATHER_USAGE_STATS": "false",
+                "QTWEBENGINE_CHROMIUM_FLAGS": "--disable-gpu",
+            },
+        )
+        if native_run.returncode != 0:
+            raise SystemExit(
+                "Native desktop-window smoke failed:\n"
+                f"{native_run.stdout}\n{native_run.stderr}"
+            )
+        print("Native fp-tools window rendered successfully")
+        return 0
 
 
 if __name__ == "__main__":

--- a/src/fp_tools/__init__.py
+++ b/src/fp_tools/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0rc11"
+__version__ = "0.2.0rc12"
 
 __all__ = ["__version__"]

--- a/src/fp_tools/desktop.py
+++ b/src/fp_tools/desktop.py
@@ -13,6 +13,8 @@ INTERNAL_MATCH_BEDS_FLAG = "--fp-tools-internal-match-beds"
 INTERNAL_PYTHON_SCRIPT_FLAG = "--fp-tools-internal-python-script"
 INTERNAL_LIST_EXAMPLES_FLAG = "--fp-tools-internal-list-gui-examples"
 INTERNAL_SMOKE_HELPS_FLAG = "--fp-tools-internal-smoke-command-helps"
+INTERNAL_GUI_SERVER_FLAG = "--fp-tools-internal-gui-server"
+INTERNAL_NATIVE_SMOKE_FLAG = "--fp-tools-internal-native-window-smoke"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -64,10 +66,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.argv = previous
         return 0
 
-    from fp_tools.cli_gui import main as gui_main
+    if arguments and arguments[0] == INTERNAL_GUI_SERVER_FLAG:
+        from fp_tools.cli_gui import main as gui_main
 
-    gui_main(arguments)
-    return 0
+        gui_main([*arguments[1:], "--no-browser"])
+        return 0
+
+    from fp_tools.desktop_window import DesktopLaunchError, launch_native_gui, show_desktop_error
+
+    auto_close = bool(arguments and arguments[0] == INTERNAL_NATIVE_SMOKE_FLAG)
+    if auto_close:
+        arguments = arguments[1:]
+    try:
+        return launch_native_gui(arguments, auto_close=auto_close)
+    except DesktopLaunchError as exc:
+        return show_desktop_error(str(exc))
 
 
 if __name__ == "__main__":

--- a/src/fp_tools/desktop_window.py
+++ b/src/fp_tools/desktop_window.py
@@ -1,0 +1,253 @@
+"""Native window for the frozen Windows and macOS fp-tools applications."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import IO, Sequence
+
+from fp_tools.cli_gui import _find_free_port, _state_dir
+from fp_tools.gui_jobs import default_gui_run_dir
+
+
+class DesktopLaunchError(RuntimeError):
+    """Raised when the bundled GUI cannot be started safely."""
+
+
+def launch_native_gui(
+    argv: Sequence[str] | None = None,
+    *,
+    auto_close: bool = False,
+) -> int:
+    """Run the command-backed Streamlit GUI in a native Qt window."""
+
+    args = _parse_desktop_args(argv)
+    run_dir = Path(args.run_dir).expanduser().resolve()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    port = args.port if args.port is not None else _find_free_port()
+    url = f"http://127.0.0.1:{port}"
+    state_dir = _state_dir(run_dir)
+    log_path = state_dir / "desktop-server.log"
+
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        process = _start_server(port, run_dir, log_handle)
+        try:
+            _wait_for_server(process, url, log_path)
+            return _run_window(url, state_dir, auto_close=auto_close)
+        finally:
+            _stop_process_tree(process)
+
+
+def show_desktop_error(message: str) -> int:
+    """Display a launch failure in a native dialog when Qt is available."""
+
+    try:
+        from PySide6.QtWidgets import QApplication, QMessageBox
+    except ImportError:
+        print(f"fp-tools could not start: {message}", file=sys.stderr)
+        return 1
+
+    application = QApplication.instance() or QApplication(["fp-tools"])
+    QMessageBox.critical(None, "fp-tools", message)
+    if QApplication.instance() is application:
+        application.processEvents()
+    return 1
+
+
+def _parse_desktop_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Launch the fp-tools desktop application."
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Optional local port (default: first free port from 8891).",
+    )
+    parser.add_argument(
+        "--run-dir",
+        default=str(default_gui_run_dir()),
+        help="Directory for GUI-managed runs.",
+    )
+    parser.add_argument("--no-browser", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args(list(argv or []))
+    if args.host not in {"127.0.0.1", "localhost", "::1"}:
+        raise DesktopLaunchError(
+            "The desktop application only accepts a local connection. "
+            "Use the Python fp-tools-gui command for remote or network access."
+        )
+    return args
+
+
+def _server_command(port: int, run_dir: Path) -> list[str]:
+    return [
+        sys.executable,
+        "--fp-tools-internal-gui-server",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--run-dir",
+        str(run_dir),
+        "--no-browser",
+    ]
+
+
+def _start_server(
+    port: int, run_dir: Path, log_handle: IO[str]
+) -> subprocess.Popen[str]:
+    kwargs: dict[str, object] = {
+        "cwd": str(run_dir),
+        "env": {
+            **os.environ,
+            "STREAMLIT_BROWSER_GATHER_USAGE_STATS": "false",
+        },
+        "stdout": log_handle,
+        "stderr": subprocess.STDOUT,
+        "text": True,
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        ) | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(_server_command(port, run_dir), **kwargs)
+
+
+def _wait_for_server(
+    process: subprocess.Popen[str],
+    url: str,
+    log_path: Path,
+    *,
+    timeout: float = 120.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise DesktopLaunchError(
+                "The local GUI server stopped during startup. "
+                f"Details were written to {log_path}."
+            )
+        try:
+            with urllib.request.urlopen(f"{url}/_stcore/health", timeout=2) as response:
+                if response.status == 200:
+                    return
+        except Exception as exc:  # normal startup polling
+            last_error = exc
+            time.sleep(0.25)
+    raise DesktopLaunchError(
+        "The local GUI server did not become ready within two minutes. "
+        f"Details were written to {log_path}. Last error: {last_error}"
+    )
+
+
+def _run_window(url: str, state_dir: Path, *, auto_close: bool) -> int:
+    if auto_close:
+        os.environ.setdefault("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu")
+        if sys.platform != "darwin":
+            os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    try:
+        from PySide6.QtCore import QTimer, QUrl
+        from PySide6.QtGui import QIcon
+        from PySide6.QtWebEngineCore import QWebEngineProfile
+        from PySide6.QtWebEngineWidgets import QWebEngineView
+        from PySide6.QtWidgets import QApplication, QMainWindow
+    except ImportError as exc:
+        raise DesktopLaunchError(
+            "The native window component is missing from this desktop bundle."
+        ) from exc
+
+    application = QApplication.instance() or QApplication(["fp-tools"])
+    application.setApplicationDisplayName("fp-tools")
+    application.setApplicationName("fp-tools")
+    icon_path = _bundled_icon_path()
+    if icon_path is not None:
+        application.setWindowIcon(QIcon(str(icon_path)))
+
+    profile = QWebEngineProfile.defaultProfile()
+    profile.setCachePath(str(state_dir / "web-cache"))
+    profile.setPersistentStoragePath(str(state_dir / "web-storage"))
+
+    window = QMainWindow()
+    window.setWindowTitle("fp-tools")
+    if icon_path is not None:
+        window.setWindowIcon(QIcon(str(icon_path)))
+    view = QWebEngineView(window)
+    window.setCentralWidget(view)
+    window.setMinimumSize(900, 640)
+    geometry = application.primaryScreen().availableGeometry()
+    window.resize(
+        min(1440, int(geometry.width() * 0.92)), min(960, int(geometry.height() * 0.92))
+    )
+
+    load_failed = [False]
+
+    def loaded(ok: bool) -> None:
+        if not ok:
+            load_failed[0] = True
+            application.quit()
+        elif auto_close:
+            QTimer.singleShot(750, application.quit)
+
+    view.loadFinished.connect(loaded)
+    view.setUrl(QUrl(url))
+    window.show()
+    if auto_close:
+        QTimer.singleShot(45_000, application.quit)
+    return_code = application.exec()
+    if load_failed[0]:
+        raise DesktopLaunchError(
+            "The fp-tools interface could not be rendered in the desktop window."
+        )
+    return int(return_code)
+
+
+def _bundled_icon_path() -> Path | None:
+    root = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parents[2]))
+    candidates = [
+        root / "fp_tools" / "resources" / "fp_tools_logo_icon_1024.png",
+        root / "docs" / "assets" / "fp_tools_logo_icon_1024.png",
+    ]
+    return next((path for path in candidates if path.is_file()), None)
+
+
+def _stop_process_tree(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            process.kill()
+        else:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        process.wait(timeout=15)

--- a/src/fp_tools/gui_app.py
+++ b/src/fp_tools/gui_app.py
@@ -726,14 +726,17 @@ def _apply_page_style() -> None:
             margin: 0.35rem 0 0.55rem;
             padding-left: 1.2rem;
             white-space: normal;
+            overflow-x: hidden;
         }
-        .fp-validation-errors li {
+        .fp-validation-errors li,
+        .fp-validation-errors li * {
+            box-sizing: border-box;
             min-width: 0;
             max-width: 100%;
             margin: 0.24rem 0;
-            overflow-wrap: anywhere;
-            word-break: break-word;
-            white-space: normal;
+            overflow-wrap: anywhere !important;
+            word-break: break-all !important;
+            white-space: normal !important;
         }
         .fp-tutorial-panel {
             background: #eaf2ff;

--- a/src/fp_tools/resources/runtime_manifest.json
+++ b/src/fp_tools/resources/runtime_manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "runtime_version": "0.2.0rc11",
-  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc11",
+  "runtime_version": "0.2.0rc12",
+  "release_base_url": "https://github.com/oncologylab/fp-tools/releases/download/v0.2.0rc12",
   "components": {
     "core": {
       "commands": [
@@ -37,23 +37,23 @@
   },
   "artifacts": {
     "linux-x86_64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc11-linux-x86_64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-linux-x86_64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc11-linux-x86_64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc12-linux-x86_64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc12-linux-x86_64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc12-linux-x86_64.tar.gz"}
     },
     "linux-arm64": {
-      "core": {"filename": "fp-tools-runtime-core-0.2.0rc11-linux-arm64.tar.gz"},
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-linux-arm64.tar.gz"},
-      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc11-linux-arm64.tar.gz"}
+      "core": {"filename": "fp-tools-runtime-core-0.2.0rc12-linux-arm64.tar.gz"},
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc12-linux-arm64.tar.gz"},
+      "homer": {"filename": "fp-tools-runtime-homer-0.2.0rc12-linux-arm64.tar.gz"}
     },
     "macos-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-macos-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc12-macos-x86_64.tar.gz"}
     },
     "macos-arm64": {
-      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc11-macos-arm64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-meme-0.2.0rc12-macos-arm64.tar.gz"}
     },
     "windows-x86_64": {
-      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc11-linux-x86_64.tar.gz"}
+      "meme": {"filename": "fp-tools-runtime-wsl-meme-0.2.0rc12-linux-x86_64.tar.gz"}
     }
   }
 }

--- a/src/fp_tools/tools/diff_footprints.py
+++ b/src/fp_tools/tools/diff_footprints.py
@@ -681,6 +681,12 @@ def _load_reuse_motif_lookup(args, logger):
     return motif_lookup
 
 
+def _logical_command_name(args):
+    """Return the public command name for the shared motif-analysis engine."""
+
+    return "match-motifs" if getattr(args, "match_only", False) else "diff-footprints"
+
+
 def run_diff_footprints_reuse_existing_results(args):
     """Regenerate final diff-footprints reports from completed motif-level outputs."""
 
@@ -2107,9 +2113,10 @@ def run_diff_footprints(args):
         outfiles.append(os.path.abspath(os.path.join(args.outdir, args.prefix + "_results_skewness_report.pdf")))
 
     # ------------------------------ logger/pools ------------------------------ #
-    logger = FpToolsLogger("diff-footprints", args.verbosity)
+    command_name = _logical_command_name(args)
+    logger = FpToolsLogger(command_name, args.verbosity)
     logger.begin()
-    parser = add_diff_footprints_arguments(argparse.ArgumentParser())
+    parser = add_diff_footprints_arguments(argparse.ArgumentParser(), command_name=command_name)
     logger.arguments_overview(parser, args)
     logger.output_files(outfiles)
 
@@ -2740,7 +2747,10 @@ def run_diff_footprints(args):
 
     # ------------------------------ plots ------------------------------------ #
     if no_conditions > 1:
-        logger.info("Creating diff-footprints plot(s)")
+        if getattr(args, "match_only", False):
+            logger.info("Creating match-motifs summary output(s)")
+        else:
+            logger.info("Creating diff-footprints plot(s)")
         change_cols = [c for c in info_table.columns if "_change" in c]
         pvalue_cols = [c for c in info_table.columns if "_pvalue" in c]
         info_table[change_cols] = info_table[change_cols].fillna(0)

--- a/tests/test_cli_golden_regressions.py
+++ b/tests/test_cli_golden_regressions.py
@@ -330,7 +330,7 @@ class CliGoldenRegressionTest(unittest.TestCase):
     def test_diff_footprints_summary_mode_skips_per_motif_exports(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             outdir = pathlib.Path(tmpdir) / "diff_footprints_summary"
-            run_command(
+            completed = run_command(
                 [
                     BIN / "diff-footprints",
                     "--signals",
@@ -357,17 +357,61 @@ class CliGoldenRegressionTest(unittest.TestCase):
                     "--motif-outputs",
                     "summary",
                     "--verbosity",
-                    "1",
+                    "2",
                 ],
                 timeout=120,
             )
             results = pd.read_csv(outdir / "diff_footprints_probe_results.txt", sep="\t")
 
+        self.assertIn("diff-footprints (run started", completed.stdout)
+        self.assertIn("Creating diff-footprints plot(s)", completed.stdout)
+        self.assertIn("Finished diff-footprints run", completed.stdout)
         self.assertEqual(len(results), 1)
         self.assertEqual(int(results.iloc[0]["total_tfbs"]), 3269)
         self.assertAlmostEqual(float(results.iloc[0]["Bcell_Tcell_change"]), 0.35168, places=5)
         self.assertFalse((outdir / "IRF1_MA0050.2" / "beds" / "IRF1_MA0050.2_all.bed").exists())
         self.assertFalse((outdir / "IRF1_MA0050.2" / "IRF1_MA0050.2_overview.txt").exists())
+
+    def test_match_motifs_logs_use_public_command_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outdir = pathlib.Path(tmpdir) / "match_motifs_logging"
+            completed = run_command(
+                [
+                    BIN / "match-motifs",
+                    "--signals",
+                    "test_data/Bcell_footprints.bw",
+                    "test_data/Tcell_footprints.bw",
+                    "--motifs",
+                    "test_data/individual_motifs/MA0050.2.jaspar",
+                    "--genome",
+                    "test_data/genome.fa.gz",
+                    "--peaks",
+                    "test_data/merged_peaks.bed",
+                    "--sample-names",
+                    "Bcell",
+                    "Tcell",
+                    "--cond-names",
+                    "Bcell",
+                    "Tcell",
+                    "--outdir",
+                    outdir,
+                    "--cores",
+                    max_cores(),
+                    "--skip-excel",
+                    "--plot-aggregate",
+                    "off",
+                    "--motif-outputs",
+                    "summary",
+                    "--verbosity",
+                    "2",
+                ],
+                timeout=120,
+            )
+
+        self.assertIn("match-motifs (run started", completed.stdout)
+        self.assertIn("Creating match-motifs summary output(s)", completed.stdout)
+        self.assertIn("Finished match-motifs run", completed.stdout)
+        self.assertNotIn("diff-footprints", completed.stdout)
 
     def test_match_motifs_auto_writes_compact_cache_and_per_motif_beds(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -72,6 +72,13 @@ class GuiLauncherTests(unittest.TestCase):
         self.assertIn("&lt;sample&gt; &amp; comparison", markup)
         self.assertNotIn("<sample>", markup)
 
+        fake_streamlit = MagicMock()
+        with patch.object(gui_app, "st", fake_streamlit):
+            gui_app._apply_page_style()
+        style = fake_streamlit.markdown.call_args.args[0]
+        self.assertIn("overflow-wrap: anywhere !important", style)
+        self.assertIn("word-break: break-all !important", style)
+
     def test_run_control_state_tracks_validation_and_keeps_launch_guard(self):
         normalized = {
             "version": 1,

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, patch
 
 from fp_tools import gui_app
 from fp_tools.command_registry import COMMAND_TARGETS, dispatch_command
-from fp_tools.desktop import INTERNAL_LIST_EXAMPLES_FLAG, main as desktop_main
+from fp_tools.desktop import (
+    INTERNAL_GUI_SERVER_FLAG,
+    INTERNAL_LIST_EXAMPLES_FLAG,
+    INTERNAL_NATIVE_SMOKE_FLAG,
+    main as desktop_main,
+)
+from fp_tools.desktop_window import DesktopLaunchError, _parse_desktop_args, _server_command
 from fp_tools.gui_app import (
     GENERIC_TOOL_DEFAULTS,
     _all_example_files,
@@ -23,6 +29,36 @@ from fp_tools.utils.subprocess_commands import (
 
 
 class GuiLauncherTests(unittest.TestCase):
+    def test_desktop_default_opens_native_window(self):
+        with patch("fp_tools.desktop_window.launch_native_gui", return_value=0) as launch:
+            self.assertEqual(desktop_main(["--run-dir", "runs"]), 0)
+        launch.assert_called_once_with(["--run-dir", "runs"], auto_close=False)
+
+    def test_desktop_native_smoke_uses_auto_close(self):
+        with patch("fp_tools.desktop_window.launch_native_gui", return_value=0) as launch:
+            self.assertEqual(
+                desktop_main([INTERNAL_NATIVE_SMOKE_FLAG, "--run-dir", "runs"]),
+                0,
+            )
+        launch.assert_called_once_with(["--run-dir", "runs"], auto_close=True)
+
+    def test_desktop_internal_server_never_opens_browser(self):
+        with patch("fp_tools.cli_gui.main") as launch:
+            self.assertEqual(
+                desktop_main([INTERNAL_GUI_SERVER_FLAG, "--port", "8898"]),
+                0,
+            )
+        launch.assert_called_once_with(["--port", "8898", "--no-browser"])
+
+    def test_desktop_window_is_local_and_spawns_private_server(self):
+        args = _parse_desktop_args(["--port", "8899", "--run-dir", "runs"])
+        self.assertEqual(args.port, 8899)
+        command = _server_command(args.port, Path(args.run_dir))
+        self.assertEqual(command[1], INTERNAL_GUI_SERVER_FLAG)
+        self.assertIn("--no-browser", command)
+        with self.assertRaises(DesktopLaunchError):
+            _parse_desktop_args(["--host", "0.0.0.0"])
+
     def test_validation_error_markup_wraps_paths_and_escapes_html(self):
         markup = _validation_errors_markup(
             [

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -57,6 +57,24 @@ class ReleaseMetadataTest(unittest.TestCase):
         self.assertIn("scripts/build_desktop_icons.py", workflow)
         self.assertIn("PySide6", workflow)
         self.assertIn("Contents/Resources/fp-tools.icns", workflow)
+        self.assertIn("codesign --verify --deep --strict", workflow)
+        self.assertIn("lipo -archs", workflow)
+        self.assertIn("xattr -dr com.apple.quarantine", workflow)
+        self.assertIn('hdiutil verify "${dmg}"', workflow)
+        self.assertIn("OPEN-FIRST-macOS.txt", workflow)
+
+        first_launch = (ROOT / "packaging/desktop/OPEN-FIRST-macOS.txt").read_text(
+            encoding="utf-8"
+        )
+        instruction = (
+            "xattr -dr com.apple.quarantine /Applications/fp-tools.app "
+            "&& open /Applications/fp-tools.app"
+        )
+        self.assertIn(instruction, first_launch)
+        installation = (ROOT / "docs/get-started/installation.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(instruction, installation)
 
         with tempfile.TemporaryDirectory() as directory:
             ico_path, icns_path = build_icons(

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -2,8 +2,13 @@ import json
 import pathlib
 import subprocess
 import sys
+import tempfile
 import tomllib
 import unittest
+
+from PIL import Image
+
+from scripts.build_desktop_icons import build_icons
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -38,6 +43,31 @@ class ReleaseMetadataTest(unittest.TestCase):
         self.assertIn(f"<string>{version}</string>", info_plist)
         example = (ROOT / "examples/nutrient_stress_project/run_ctrl_vs_10fbs.sh").read_text(encoding="utf-8")
         self.assertIn(f'VERSION="${{FP_TOOLS_VERSION:-{version}}}"', example)
+
+    def test_desktop_bundles_have_branded_native_window_assets(self):
+        info_plist = (ROOT / "packaging/desktop/Info.plist").read_text(encoding="utf-8")
+        self.assertIn("<key>CFBundleIconFile</key><string>fp-tools.icns</string>", info_plist)
+
+        spec = (ROOT / "packaging/desktop/fp-tools-gui.spec").read_text(encoding="utf-8")
+        self.assertIn('icon=str(icon_path)', spec)
+        self.assertIn('hide_console="hide-early"', spec)
+        self.assertIn("fp_tools_logo_icon_1024.png", spec)
+
+        workflow = (ROOT / ".github/workflows/desktop.yml").read_text(encoding="utf-8")
+        self.assertIn("scripts/build_desktop_icons.py", workflow)
+        self.assertIn("PySide6", workflow)
+        self.assertIn("Contents/Resources/fp-tools.icns", workflow)
+
+        with tempfile.TemporaryDirectory() as directory:
+            ico_path, icns_path = build_icons(
+                ROOT / "docs/assets/fp_tools_logo_icon_1024.png",
+                pathlib.Path(directory),
+            )
+            with Image.open(ico_path) as icon:
+                self.assertIn((16, 16), icon.ico.sizes())
+                self.assertIn((256, 256), icon.ico.sizes())
+            with Image.open(icns_path) as icon:
+                self.assertEqual(icon.size, (1024, 1024))
 
     def test_release_checklist_documents_required_gates(self):
         checklist = (ROOT / "RELEASE_CHECKLIST.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- make the shared motif-analysis engine retain the public `match-motifs` command name in run headers and completion logs
- prepare release candidate 0.2.0rc12 with focused command-label regressions
- give the Windows and Apple Silicon downloads branded operating-system icons and a self-contained native application window
- keep the normal Python/server GUI browser-based while desktop apps privately host the same command-backed interface
- ad-hoc sign and strictly verify the unsigned Apple Silicon preview, verify and mount its DMG, and include a one-line first-launch instruction
- test the documented quarantine-removal command and native window on the Apple Silicon builder
- retry transient macOS `hdiutil` resource contention during packaging

## Verification
- 408 tests passed, 1 skipped before the macOS distribution follow-up
- focused release, GUI, and icon-generation regressions passed after the follow-up
- all console-script smoke tests and `pip check` passed
- strict MkDocs build passed
- 32 pages passed browser auditing at three viewport sizes in both supported color schemes
- Windows and Apple Silicon jobs exercise the private GUI server, bundled native window, and responsive interface
- the updated Apple Silicon job additionally checks ad-hoc signing, ARM64 architecture, quarantine removal, DMG integrity, and mounted contents

Fixes #48